### PR TITLE
[Composer] Set minimum-stability and prefer-stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
             "EzSystems\\EzPlatformRest\\Tests\\": "tests/lib/"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "^7.1",
         "ezsystems/ezpublish-kernel": "^8.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
-        "ezsystems/doctrine-dbal-schema": "^1.0@dev"
+        "ezsystems/ezpublish-kernel": "^8.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5.11",


### PR DESCRIPTION
I really like the solution provided by @mnocon which combines Composer's `"minimum-stability": "dev"` and `"prefer-stable": true` settings. 

This way we can avoid explicitly setting `@dev` versions of dependencies of dependencies when there's no stable version yet.

At the same time we want to avoid installing 3rd party unstable packages, hence `prefer-stable` is set to true.

This PR:
- [x] adds "minimum-stability": "dev" & "prefer-stable": true to composer.json,
- [x] drops no longer required `doctrine-dbal-schema` dependency.