### PR TITLE
EZP-30685: As a Developer I want to easier generate attribute/value elements in Value Object Visitors

### DIFF
--- a/src/lib/Output/Generator.php
+++ b/src/lib/Output/Generator.php
@@ -185,6 +185,18 @@ abstract class Generator
     }
 
     /**
+     * Generate value element with given $name and $value.
+     *
+     * @param string $name
+     * @param mixed $value
+     */
+    public function valueElement(string $name, $value): void
+    {
+        $this->startValueElement($name, $value);
+        $this->endValueElement($name);
+    }
+
+    /**
      * Start value element.
      *
      * @param string $name
@@ -251,6 +263,18 @@ abstract class Generator
     protected function checkEndList($data)
     {
         $this->checkEnd('list', $data);
+    }
+
+    /**
+     * Generate attribute with given $name and $value.
+     *
+     * @param string $name
+     * @param mixed $value
+     */
+    public function attribute(string $name, $value): void
+    {
+        $this->startAttribute($name, $value);
+        $this->endAttribute($name);
     }
 
     /**

--- a/tests/lib/Output/Generator/JsonTest.php
+++ b/tests/lib/Output/Generator/JsonTest.php
@@ -88,6 +88,24 @@ class JsonTest extends GeneratorTest
 
         $generator->startObjectElement('element');
 
+        $generator->attribute('attribute', 'value');
+
+        $generator->endObjectElement('element');
+
+        $this->assertSame(
+            '{"element":{"_media-type":"application\/vnd.ez.api.element+json","_attribute":"value"}}',
+            $generator->endDocument('test')
+        );
+    }
+
+    public function testGeneratorStartEndAttribute()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+
+        $generator->startObjectElement('element');
+
         $generator->startAttribute('attribute', 'value');
         $generator->endAttribute('attribute');
 
@@ -107,11 +125,8 @@ class JsonTest extends GeneratorTest
 
         $generator->startObjectElement('element');
 
-        $generator->startAttribute('attribute1', 'value');
-        $generator->endAttribute('attribute1');
-
-        $generator->startAttribute('attribute2', 'value');
-        $generator->endAttribute('attribute2');
+        $generator->attribute('attribute1', 'value');
+        $generator->attribute('attribute2', 'value');
 
         $generator->endObjectElement('element');
 
@@ -122,6 +137,24 @@ class JsonTest extends GeneratorTest
     }
 
     public function testGeneratorValueElement()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+
+        $generator->startObjectElement('element');
+
+        $generator->valueElement('value', '42');
+
+        $generator->endObjectElement('element');
+
+        $this->assertSame(
+            '{"element":{"_media-type":"application\/vnd.ez.api.element+json","value":"42"}}',
+            $generator->endDocument('test')
+        );
+    }
+
+    public function testGeneratorStartEndValueElement()
     {
         $generator = $this->getGenerator();
 

--- a/tests/lib/Output/Generator/XmlTest.php
+++ b/tests/lib/Output/Generator/XmlTest.php
@@ -86,6 +86,24 @@ class XmlTest extends GeneratorTest
 
         $generator->startObjectElement('element');
 
+        $generator->attribute('attribute', 'value');
+
+        $generator->endObjectElement('element');
+
+        $this->assertSame(
+            file_get_contents(__DIR__ . '/_fixtures/' . __FUNCTION__ . '.xml'),
+            $generator->endDocument('test')
+        );
+    }
+
+    public function testGeneratorStartEndAttribute()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+
+        $generator->startObjectElement('element');
+
         $generator->startAttribute('attribute', 'value');
         $generator->endAttribute('attribute');
 
@@ -105,11 +123,8 @@ class XmlTest extends GeneratorTest
 
         $generator->startObjectElement('element');
 
-        $generator->startAttribute('attribute1', 'value');
-        $generator->endAttribute('attribute1');
-
-        $generator->startAttribute('attribute2', 'value');
-        $generator->endAttribute('attribute2');
+        $generator->attribute('attribute1', 'value');
+        $generator->attribute('attribute2', 'value');
 
         $generator->endObjectElement('element');
 
@@ -120,6 +135,24 @@ class XmlTest extends GeneratorTest
     }
 
     public function testGeneratorValueElement()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+
+        $generator->startObjectElement('element');
+
+        $generator->valueElement('value', '42');
+
+        $generator->endObjectElement('element');
+
+        $this->assertSame(
+            file_get_contents(__DIR__ . '/_fixtures/' . __FUNCTION__ . '.xml'),
+            $generator->endDocument('test')
+        );
+    }
+
+    public function testGeneratorStartEndValueElement()
     {
         $generator = $this->getGenerator();
 

--- a/tests/lib/Output/Generator/_fixtures/testGeneratorStartEndAttribute.xml
+++ b/tests/lib/Output/Generator/_fixtures/testGeneratorStartEndAttribute.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<element media-type="application/vnd.ez.api.element+xml" attribute="value"/>

--- a/tests/lib/Output/Generator/_fixtures/testGeneratorStartEndValueElement.xml
+++ b/tests/lib/Output/Generator/_fixtures/testGeneratorStartEndValueElement.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<element media-type="application/vnd.ez.api.element+xml">
+ <value>42</value>
+</element>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30685

## Description 

This PR introduces two shortcut methods to simplify `\EzSystems\EzPlatformRest\Output\ValueObjectVisitor` implementation: 

* `\EzSystems\EzPlatformRest\Output\Generator::valueElement` which is equivalent to  

```php
$generator->startValueElement($name, $value);
$generator->endValueElement($name);
```
* `\EzSystems\EzPlatformRest\Output\Generator::attribute` which is equivalent to  

```php
$generator->startAttribute($name, $value);
$generator->endAttribute($name);
```


