### PR TITLE
[Tests] Allowed configuring HTTP scheme for REST tests instance

### DIFF
--- a/tests/bundle/Functional/TestCase.php
+++ b/tests/bundle/Functional/TestCase.php
@@ -37,6 +37,13 @@ class TestCase extends BaseTestCase
     private $httpHost;
 
     /**
+     * HTTP scheme (http or https).
+     *
+     * @var string
+     */
+    private $httpScheme;
+
+    /**
      * @var string
      * Basic auth login:password
      */
@@ -82,6 +89,7 @@ class TestCase extends BaseTestCase
         parent::setUp();
 
         $this->httpHost = getenv('EZP_TEST_REST_HOST') ?: 'localhost';
+        $this->httpScheme = getenv('EZP_TEST_REST_SCHEME') ?: 'http';
         $this->httpAuth = getenv('EZP_TEST_REST_AUTH') ?: 'admin:publish';
         list($this->loginUsername, $this->loginPassword) = explode(':', $this->httpAuth);
 
@@ -149,7 +157,7 @@ class TestCase extends BaseTestCase
      */
     protected function getBaseURI()
     {
-        return "http://{$this->httpHost}";
+        return "{$this->httpScheme}://{$this->httpHost}";
     }
 
     /**


### PR DESCRIPTION
This PR provides a possibility to set HTTP scheme of the eZ Platform instance for REST tests.

HTTP scheme (http or https) can be set via the new environment variable `EZP_TEST_REST_SCHEME` which falls back to `http` as default.

_Background: Symfony CLI allows to run local HTTP server with `HTTPS`, so it's quite possible more people would need it in the future._