### PR TITLE
EZP-30812: Fixed deprecated use of Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch method

### DIFF
--- a/src/lib/Server/Security/RestAuthenticator.php
+++ b/src/lib/Server/Security/RestAuthenticator.php
@@ -127,10 +127,7 @@ class RestAuthenticator implements ListenerInterface, AuthenticatorInterface
         }
 
         $this->tokenStorage->setToken($token);
-        $this->dispatcher->dispatch(
-            SecurityEvents::INTERACTIVE_LOGIN,
-            new InteractiveLoginEvent($request, $token)
-        );
+        $this->dispatcher->dispatch(new InteractiveLoginEvent($request, $token), SecurityEvents::INTERACTIVE_LOGIN);
 
         // Re-fetch token from SecurityContext since an INTERACTIVE_LOGIN listener might have changed it
         // i.e. when using multiple user providers.

--- a/tests/lib/Server/Security/RestSessionBasedAuthenticatorTest.php
+++ b/tests/lib/Server/Security/RestSessionBasedAuthenticatorTest.php
@@ -184,8 +184,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                SecurityEvents::INTERACTIVE_LOGIN,
-                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken))
+                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken)),
+                SecurityEvents::INTERACTIVE_LOGIN
             );
 
         $this->tokenStorage
@@ -258,8 +258,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                SecurityEvents::INTERACTIVE_LOGIN,
-                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken))
+                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken)),
+                SecurityEvents::INTERACTIVE_LOGIN
             );
 
         $this->tokenStorage
@@ -327,8 +327,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                SecurityEvents::INTERACTIVE_LOGIN,
-                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken))
+                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken)),
+                SecurityEvents::INTERACTIVE_LOGIN
             );
 
         $this->tokenStorage
@@ -386,8 +386,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                SecurityEvents::INTERACTIVE_LOGIN,
-                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken))
+                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken)),
+                SecurityEvents::INTERACTIVE_LOGIN
             );
 
         $this->tokenStorage
@@ -444,8 +444,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                SecurityEvents::INTERACTIVE_LOGIN,
-                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken))
+                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken)),
+                SecurityEvents::INTERACTIVE_LOGIN
             );
 
         $this->tokenStorage
@@ -497,8 +497,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
             ->expects($this->once())
             ->method('dispatch')
             ->with(
-                SecurityEvents::INTERACTIVE_LOGIN,
-                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken))
+                $this->equalTo(new InteractiveLoginEvent($request, $authenticatedToken)),
+                SecurityEvents::INTERACTIVE_LOGIN
             );
 
         $this->tokenStorage


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30812

## Description 

Fixed the following deprecation message:

```
Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.
```

by swapping argument order in  `Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()` method calls.  
