### PR TITLE
EZP-30515: Enable CSRF token in login form by default

### DIFF
--- a/tests/bundle/Functional/SessionTest.php
+++ b/tests/bundle/Functional/SessionTest.php
@@ -127,8 +127,8 @@ class SessionTest extends TestCase
         );
         $response = $this->sendHttpRequest($request);
 
-        // Since Session is reused, not created, expect 200 instead of 201
-        self::assertHttpResponseCodeEquals($response, 200);
+        // Session is recreated when using CSRF, expect 201 instead of 200
+        self::assertHttpResponseCodeEquals($response, 201);
     }
 
     /**


### PR DESCRIPTION
The equivalent of https://github.com/ezsystems/ezpublish-kernel/pull/2693 v7.5 in master - the test file has moved.

⚠ SessionTest will fail here, but passes if https://github.com/ezsystems/ezplatform/pull/435 is merged in master.