### PR TITLE
EZP-30846: Dropped deprecated Symfony\Component\Config\Definition\Builder\TreeBuilder::root method calls

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -13,10 +13,9 @@ class Configuration extends SiteAccessConfiguration
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ez_publish_rest');
+        $treeBuilder = new TreeBuilder('ez_publish_rest');
 
-        $this->addRestRootResourcesSection($rootNode);
+        $this->addRestRootResourcesSection($treeBuilder->getRootNode());
 
         return $treeBuilder;
     }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30846

## Description 

Since Symfony 4.3 configuration root name should be passed via constructor instead of using "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method.

More information:
* https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes
* https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config