### PR TITLE
Install latest dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5.11",
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,6 @@
             "EzSystems\\EzPlatformRest\\Tests\\": "tests/lib/"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": "^7.3",
         "ext-dom": "*",


### PR DESCRIPTION
Making sure correct dependencies are installed when installing this package locally, to unblock: https://github.com/ezsystems/ezplatform-rest/pull/33

Right now, because of minimum-stabiltiy and prefer stable settings, the Kernel package is installed in beta version. This PR changes that.