### PR TITLE
EZP-30971: Removed usage of deprecated role service methods

### DIFF
--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -641,7 +641,7 @@ class Role extends RestController
 
         $roleAssignments = $this->roleService->getRoleAssignmentsForUser($user);
         foreach ($roleAssignments as $roleAssignment) {
-            if ($roleAssignment->role->id === $roleId) {
+            if ($roleAssignment->role->id == $roleId) {
                 $this->roleService->removeRoleAssignment($roleAssignment);
             }
         }
@@ -666,7 +666,7 @@ class Role extends RestController
 
         $roleAssignments = $this->roleService->getRoleAssignmentsForUserGroup($userGroup);
         foreach ($roleAssignments as $roleAssignment) {
-            if ($roleAssignment->role->id === $roleId) {
+            if ($roleAssignment->role->id == $roleId) {
                 $this->roleService->removeRoleAssignment($roleAssignment);
             }
         }

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -716,6 +716,7 @@ class Role extends RestController
         foreach ($roleAssignments as $roleAssignment) {
             $policies[] = $roleAssignment->getRole()->getPolicies();
         }
+
         return new Values\PolicyList(
             array_merge(...$policies),
             $request->getPathInfo()

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -226,11 +226,15 @@ class Role extends RestController
                 $request->getContent()
             )
         );
-
-        return $this->roleService->updateRole(
-            $this->roleService->loadRole($roleId),
+        $roleDraft = $this->roleService->createRoleDraft(
+            $this->roleService->loadRole($roleId)
+        );
+        $this->roleService->updateRoleDraft(
+            $roleDraft,
             $this->mapToUpdateStruct($createStruct)
         );
+
+        return $this->roleService->loadRole($roleId);
     }
 
     /**

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -456,68 +456,13 @@ class Role extends RestController
             )
         );
 
-        try {
-            // First try to treat $roleId as a role draft ID.
-            $role = $this->roleService->loadRoleDraft($roleId);
-            foreach ($role->getPolicies() as $policy) {
-                if ($policy->id == $policyId) {
-                    try {
-                        return $this->roleService->updatePolicy(
-                            $policy,
-                            $updateStruct
-                        );
-                    } catch (LimitationValidationException $e) {
-                        throw new BadRequestException($e->getMessage());
-                    }
-                }
-            }
-        } catch (NotFoundException $e) {
-            // Then try to treat $roleId as a role ID.
-            $role = $this->roleService->loadRole($roleId);
-            foreach ($role->getPolicies() as $policy) {
-                if ($policy->id == $policyId) {
-                    try {
-                        return $this->roleService->updatePolicy(
-                            $policy,
-                            $updateStruct
-                        );
-                    } catch (LimitationValidationException $e) {
-                        throw new BadRequestException($e->getMessage());
-                    }
-                }
-            }
-        }
-
-        throw new Exceptions\NotFoundException("Policy not found: '{$request->getPathInfo()}'.");
-    }
-
-    /**
-     * Updates a policy.
-     *
-     * @since 6.2
-     * @deprecated since 6.3, use {@see updatePolicy}
-     *
-     * @param $roleId
-     * @param $policyId
-     *
-     * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy
-     */
-    public function updatePolicyByRoleDraft($roleId, $policyId, Request $request)
-    {
-        $updateStruct = $this->inputDispatcher->parse(
-            new Message(
-                ['Content-Type' => $request->headers->get('Content-Type')],
-                $request->getContent()
-            )
-        );
-
-        $role = $this->roleService->loadRoleDraft($roleId);
-        foreach ($role->getPolicies() as $policy) {
+        $roleDraft = $this->roleService->loadRoleDraft($roleId);
+        /** @var \eZ\Publish\API\Repository\Values\User\PolicyDraft $policy */
+        foreach ($roleDraft->getPolicies() as $policy) {
             if ($policy->id == $policyId) {
                 try {
-                    return $this->roleService->updatePolicy(
+                    return $this->roleService->updatePolicyByRoleDraft(
+                        $roleDraft,
                         $policy,
                         $updateStruct
                     );

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -775,7 +775,7 @@ class Role extends RestController
         }
 
         return new Values\PolicyList(
-            array_merge(...$policies),
+            !empty($policies) ? array_merge(...$policies) : [],
             $request->getPathInfo()
         );
     }

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -492,11 +492,19 @@ class Role extends RestController
             foreach ($roleDraft->getPolicies() as $policy) {
                 if ($policy->originalId == $policyId) {
                     try {
-                        return $this->roleService->updatePolicyByRoleDraft(
+                        $policyDraft = $this->roleService->updatePolicyByRoleDraft(
                             $roleDraft,
                             $policy,
                             $updateStruct
                         );
+                        $this->roleService->publishRoleDraft($roleDraft);
+                        $role = $this->roleService->loadRole($roleId);
+
+                        foreach ($role->getPolicies() as $newPolicy) {
+                            if ($newPolicy->id == $policyDraft->id) {
+                                return $newPolicy;
+                            }
+                        }
                     } catch (LimitationValidationException $e) {
                         throw new BadRequestException($e->getMessage());
                     }

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -706,10 +706,15 @@ class Role extends RestController
      */
     public function listPoliciesForUser(Request $request)
     {
+        $user = $this->userService->loadUser($request->query->get('userId'));
+        $roleAssignments = $this->roleService->getRoleAssignmentsForUser($user, true);
+
+        $policies = [];
+        foreach ($roleAssignments as $roleAssignment) {
+            $policies[] = $roleAssignment->getRole()->getPolicies();
+        }
         return new Values\PolicyList(
-            $this->roleService->loadPoliciesByUserId(
-                $request->query->get('userId')
-            ),
+            array_merge(...$policies),
             $request->getPathInfo()
         );
     }

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -581,13 +581,16 @@ class Role extends RestController
     public function unassignRoleFromUser($userId, $roleId)
     {
         $user = $this->userService->loadUser($userId);
-        $role = $this->roleService->loadRole($roleId);
-
-        $this->roleService->unassignRoleFromUser($role, $user);
 
         $roleAssignments = $this->roleService->getRoleAssignmentsForUser($user);
+        foreach ($roleAssignments as $roleAssignment) {
+            if ($roleAssignment->role->id === $roleId) {
+                $this->roleService->removeRoleAssignment($roleAssignment);
+            }
+        }
+        $newRoleAssignments = $this->roleService->getRoleAssignmentsForUser($user);
 
-        return new Values\RoleAssignmentList($roleAssignments, $user->id);
+        return new Values\RoleAssignmentList($newRoleAssignments, $user->id);
     }
 
     /**

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -383,11 +383,11 @@ class Role extends RestController
     /**
      * Adds a policy to role.
      *
-     * @param $roleId int ID of a role draft
+     * @param int $roleDraftId ID of a role draft
      *
      * @return \EzSystems\EzPlatformRest\Server\Values\CreatedPolicy
      */
-    public function addPolicy($roleId, Request $request)
+    public function addPolicy($roleDraftId, Request $request)
     {
         $createStruct = $this->inputDispatcher->parse(
             new Message(
@@ -397,9 +397,8 @@ class Role extends RestController
         );
 
         try {
-            // First try to treat $roleId as a role draft ID.
             $role = $this->roleService->addPolicyByRoleDraft(
-                $this->roleService->loadRoleDraft($roleId),
+                $this->roleService->loadRoleDraft($roleDraftId),
                 $createStruct
             );
         } catch (LimitationValidationException $e) {
@@ -440,14 +439,14 @@ class Role extends RestController
     /**
      * Updates a policy.
      *
-     * @param $roleId int ID of a role draft
-     * @param $policyId int ID of a policy
+     * @param int $roleDraftId ID of a role draft
+     * @param int $policyId ID of a policy
      *
      * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException
      *
      * @return \eZ\Publish\API\Repository\Values\User\Policy
      */
-    public function updatePolicy($roleId, $policyId, Request $request)
+    public function updatePolicy($roleDraftId, $policyId, Request $request)
     {
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
@@ -456,7 +455,7 @@ class Role extends RestController
             )
         );
 
-        $roleDraft = $this->roleService->loadRoleDraft($roleId);
+        $roleDraft = $this->roleService->loadRoleDraft($roleDraftId);
         /** @var \eZ\Publish\API\Repository\Values\User\PolicyDraft $policy */
         foreach ($roleDraft->getPolicies() as $policy) {
             if ($policy->id == $policyId) {
@@ -478,16 +477,16 @@ class Role extends RestController
     /**
      * Delete a policy from role.
      *
-     * @param $roleId int ID of a role draft
-     * @param $policyId int ID of a policy
+     * @param int $roleDraftId ID of a role draft
+     * @param int $policyId ID of a policy
      *
      * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException
      *
      * @return \EzSystems\EzPlatformRest\Server\Values\NoContent
      */
-    public function deletePolicy($roleId, $policyId, Request $request)
+    public function deletePolicy($roleDraftId, $policyId, Request $request)
     {
-        $roleDraft = $this->roleService->loadRoleDraft($roleId);
+        $roleDraft = $this->roleService->loadRoleDraft($roleDraftId);
 
         $policy = null;
         /** @var \eZ\Publish\API\Repository\Values\User\PolicyDraft $rolePolicy */

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -287,7 +287,7 @@ class Role extends RestController
 
         $this->roleService->publishRoleDraft($roleDraft);
 
-        $role = $this->roleService->loadRole($roleId);
+        $role = $this->roleService->loadRoleByIdentifier($roleDraft->identifier);
 
         return new Values\PublishedRole(['role' => new Values\RestRole($role)]);
     }

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -383,7 +383,7 @@ class Role extends RestController
     /**
      * Adds a policy to role.
      *
-     * @param $roleId int ID of a role or a role draft
+     * @param $roleId int ID of a role draft
      *
      * @return \EzSystems\EzPlatformRest\Server\Values\CreatedPolicy
      */
@@ -440,7 +440,7 @@ class Role extends RestController
     /**
      * Updates a policy.
      *
-     * @param $roleId int ID of a role or a role draft
+     * @param $roleId int ID of a role draft
      * @param $policyId int ID of a policy
      *
      * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException
@@ -478,7 +478,7 @@ class Role extends RestController
     /**
      * Delete a policy from role.
      *
-     * @param $roleId int ID of a role or a role draft
+     * @param $roleId int ID of a role draft
      * @param $policyId int ID of a policy
      *
      * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -400,47 +400,6 @@ class Role extends RestController
                 $this->roleService->loadRoleDraft($roleId),
                 $createStruct
             );
-        } catch (NotFoundException $e) {
-            // Then try to treat $roleId as a role ID.
-            $role = $this->roleService->addPolicy(
-                $this->roleService->loadRole($roleId),
-                $createStruct
-            );
-        } catch (LimitationValidationException $e) {
-            throw new BadRequestException($e->getMessage());
-        }
-
-        return new Values\CreatedPolicy(
-            [
-                'policy' => $this->getLastAddedPolicy($role),
-            ]
-        );
-    }
-
-    /**
-     * Adds a policy to a role draft.
-     *
-     * @since 6.2
-     * @deprecated since 6.3, use {@see addPolicy}
-     *
-     * @param $roleId
-     *
-     * @return \EzSystems\EzPlatformRest\Server\Values\CreatedPolicy
-     */
-    public function addPolicyByRoleDraft($roleId, Request $request)
-    {
-        $createStruct = $this->inputDispatcher->parse(
-            new Message(
-                ['Content-Type' => $request->headers->get('Content-Type')],
-                $request->getContent()
-            )
-        );
-
-        try {
-            $role = $this->roleService->addPolicyByRoleDraft(
-                $this->roleService->loadRoleDraft($roleId),
-                $createStruct
-            );
         } catch (LimitationValidationException $e) {
             throw new BadRequestException($e->getMessage());
         }

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -607,9 +607,12 @@ class Role extends RestController
         $groupLocation = $this->locationService->loadLocation(array_pop($groupLocationParts));
         $userGroup = $this->userService->loadUserGroup($groupLocation->contentId);
 
-        $role = $this->roleService->loadRole($roleId);
-        $this->roleService->unassignRoleFromUserGroup($role, $userGroup);
-
+        $roleAssignments = $this->roleService->getRoleAssignmentsForUserGroup($userGroup);
+        foreach ($roleAssignments as $roleAssignment) {
+            if ($roleAssignment->role->id === $roleId) {
+                $this->roleService->removeRoleAssignment($roleAssignment);
+            }
+        }
         $roleAssignments = $this->roleService->getRoleAssignmentsForUserGroup($userGroup);
 
         return new Values\RoleAssignmentList($roleAssignments, $groupPath, true);

--- a/src/lib/Server/Controller/Role.php
+++ b/src/lib/Server/Controller/Role.php
@@ -502,8 +502,8 @@ class Role extends RestController
                     }
                 }
             }
-            throw new BadRequestException($roleDraft->getPolicies()[0]->originalId . '/' . $policyId);
         }
+
         throw new Exceptions\NotFoundException("Policy not found: '{$request->getPathInfo()}'.");
     }
 
@@ -758,7 +758,7 @@ class Role extends RestController
      */
     public function listPoliciesForUser(Request $request)
     {
-        $user = $this->userService->loadUser($request->query->get('userId'));
+        $user = $this->userService->loadUser((int)$request->query->get('userId'));
         $roleAssignments = $this->roleService->getRoleAssignmentsForUser($user, true);
 
         $policies = [];

--- a/tests/bundle/Functional/RoleTest.php
+++ b/tests/bundle/Functional/RoleTest.php
@@ -367,6 +367,8 @@ XML;
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
+
+        return json_decode($response->getBody(), true)['Policy']['_href'];
     }
 
     /**
@@ -610,7 +612,7 @@ XML;
     /**
      * Covers DELETE /user/roles/{roleId}/policies/{policyId}.
      *
-     * @depends testAddPolicy
+     * @depends testUpdatePolicy
      */
     public function testDeletePolicy($policyHref)
     {

--- a/tests/bundle/Functional/RoleTest.php
+++ b/tests/bundle/Functional/RoleTest.php
@@ -229,48 +229,6 @@ XML;
     /**
      * Covers POST /user/roles/{roleId}/policies.
      *
-     * @depends testCreateRole
-     *
-     * @return string The created policy href
-     */
-    public function testAddPolicy($roleHref)
-    {
-        // @todo Error in Resource URL in spec @ https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#151213create-policy
-        $xml = <<< XML
-<?xml version="1.0" encoding="UTF-8"?>
-<PolicyCreate>
-  <module>content</module>
-  <function>create</function>
-  <limitations>
-    <limitation identifier="Class">
-      <values>
-        <ref href="2"/>
-      </values>
-    </limitation>
-  </limitations>
-</PolicyCreate>
-XML;
-        $request = $this->createHttpRequest(
-            'POST',
-            "$roleHref/policies",
-            'PolicyCreate+xml',
-            'Policy+json',
-            $xml
-        );
-        $response = $this->sendHttpRequest($request);
-
-        self::assertHttpResponseCodeEquals($response, 201);
-        self::assertHttpResponseHasHeader($response, 'Location');
-
-        $href = $response->getHeader('Location')[0];
-        $this->addCreatedElement($href);
-
-        return $href;
-    }
-
-    /**
-     * Covers POST /user/roles/{roleId}/policies.
-     *
      * @depends testCreateRoleDraft
      *
      * @return string The created policy href

--- a/tests/bundle/Functional/RoleTest.php
+++ b/tests/bundle/Functional/RoleTest.php
@@ -229,6 +229,48 @@ XML;
     /**
      * Covers POST /user/roles/{roleId}/policies.
      *
+     * @depends testCreateRole
+     *
+     * @return string The created policy href
+     */
+    public function testAddPolicy($roleHref)
+    {
+        // @todo Error in Resource URL in spec @ https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#151213create-policy
+        $xml = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<PolicyCreate>
+  <module>content</module>
+  <function>create</function>
+  <limitations>
+    <limitation identifier="Class">
+      <values>
+        <ref href="2"/>
+      </values>
+    </limitation>
+  </limitations>
+</PolicyCreate>
+XML;
+        $request = $this->createHttpRequest(
+            'POST',
+            "$roleHref/policies",
+            'PolicyCreate+xml',
+            'Policy+json',
+            $xml
+        );
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 201);
+        self::assertHttpResponseHasHeader($response, 'Location');
+
+        $href = $response->getHeader('Location')[0];
+        $this->addCreatedElement($href);
+
+        return $href;
+    }
+
+    /**
+     * Covers POST /user/roles/{roleId}/policies.
+     *
      * @depends testCreateRoleDraft
      *
      * @return string The created policy href


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30971](https://jira.ez.no/browse/EZP-30971)
| **Type**           | Improvement
| **Target version** | `master`
| **BC breaks**      | yes
| **Doc needed**     | yes

As additional thing, some methods were cleared up to use only `roleDraftId` and not `try/catch` to guess if you passed `roleDraftId` or `roleId`.