### PR TITLE
EZP-31115: Added `isHidden` flag to `ContentInfo` in REST response

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestContent.php
@@ -178,6 +178,12 @@ class RestContent extends ValueObjectVisitor
         $generator->endValueElement('alwaysAvailable');
 
         $generator->startValueElement(
+            'isHidden',
+            $this->serializeBool($generator, $contentInfo->isHidden)
+        );
+        $generator->endValueElement('isHidden');
+
+        $generator->startValueElement(
             'status',
             $this->getStatusString($contentInfo->status)
         );

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestContentTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestContentTest.php
@@ -112,6 +112,7 @@ class RestContentTest extends ValueObjectVisitorBaseTest
                     'mainLanguageCode' => 'eng-US',
                     'mainLocationId' => 'location23',
                     'contentTypeId' => 'contentType23',
+                    'isHidden' => true,
                 ]
             ),
             new Values\Content\Location(
@@ -351,6 +352,16 @@ class RestContentTest extends ValueObjectVisitorBaseTest
     public function testAlwaysAvailableCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/alwaysAvailable[text()="true"]');
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitWithoutEmbeddedVersion
+     */
+    public function testIsHiddenCorrect(\DOMDocument $dom)
+    {
+        $this->assertXPath($dom, '/Content/isHidden[text()="true"]');
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31115](https://jira.ez.no/browse/EZP-31115)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added `isHidden` flag to `ContentInfo` in REST response

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
