### PR TITLE
EZP-31183: Dropped support for Criteria element in REST search queries

### DIFF
--- a/src/lib/Server/Input/Parser/Query.php
+++ b/src/lib/Server/Input/Parser/Query.php
@@ -29,20 +29,6 @@ abstract class Query extends CriterionParser
     {
         $query = $this->buildQuery();
 
-        // @deprecated Criteria
-        // -- FullTextCriterion
-        if (array_key_exists('Criteria', $data) && is_array($data['Criteria'])) {
-            $message = 'The Criteria element is deprecated since ezpublish-kernel 6.6, and will be removed in 8.0. Use Filter instead, or Query for criteria that should affect scoring.';
-            if (array_key_exists('Filter', $data) && is_array($data['Filter'])) {
-                $message .= ' The Criteria element will be merged into Filter.';
-                $data['Filter'] = array_merge($data['Filter'], $data['Criteria']);
-            } else {
-                $data['Filter'] = $data['Criteria'];
-            }
-
-            @trigger_error($message, E_USER_DEPRECATED);
-        }
-
         if (array_key_exists('Filter', $data) && is_array($data['Filter'])) {
             $query->filter = $this->processCriteriaArray($data['Filter'], $parsingDispatcher);
         }

--- a/tests/bundle/Functional/ContentTest.php
+++ b/tests/bundle/Functional/ContentTest.php
@@ -421,35 +421,6 @@ XML;
         return $array['Content'];
     }
 
-    public function testCreateView()
-    {
-        $body = <<< XML
-<?xml version="1.0" encoding="UTF-8"?>
-<ViewInput>
-  <identifier>testCreateView</identifier>
-  <Query>
-    <Criteria>
-      <ContentTypeIdentifierCriterion>folder</ContentTypeIdentifierCriterion>
-    </Criteria>
-    <limit>10</limit>
-    <offset>0</offset>
-  </Query>
-</ViewInput>
-XML;
-        $request = $this->createHttpRequest(
-            'POST',
-            '/api/ezp/v2/content/views',
-            'ViewInput+xml',
-            'View+json',
-            $body
-        );
-        $response = $this->sendHttpRequest($request);
-
-        // Returns 301 since 6.0 (deprecated in favour of /views)
-        self::assertHttpResponseCodeEquals($response, 301);
-        self::assertHttpResponseHasHeader($response, 'Location');
-    }
-
     /**
      * Covers DELETE /content/objects/<contentId>/versions/<versionNo>/translations/<languageCode>.
      *

--- a/tests/lib/Server/Input/Parser/FacetBuilder/FacetBuilderParserTest.php
+++ b/tests/lib/Server/Input/Parser/FacetBuilder/FacetBuilderParserTest.php
@@ -23,7 +23,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'ContentType' => [
@@ -58,7 +57,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'ContentType' => [],
@@ -81,7 +79,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'Criterion' => [
@@ -108,7 +105,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'Field' => [
@@ -143,7 +139,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'Location' => [
@@ -170,7 +165,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'Section' => [],
@@ -193,7 +187,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'Term' => [],
@@ -216,7 +209,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'User' => [
@@ -243,7 +235,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [],
         ];
@@ -262,7 +253,6 @@ class FacetBuilderParserTest extends FacetBuilderBaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
             'FacetBuilders' => [
                 'ContentType' => [],

--- a/tests/lib/Server/Input/Parser/QueryParserTest.php
+++ b/tests/lib/Server/Input/Parser/QueryParserTest.php
@@ -15,7 +15,6 @@ class QueryParserTest extends BaseTest
     {
         $inputArray = [
             'Filter' => [],
-            'Criteria' => [],
             'Query' => [],
         ];
 
@@ -33,7 +32,6 @@ class QueryParserTest extends BaseTest
     {
         $inputArray = [
             'Filter' => ['ContentTypeIdentifierCriterion' => 'article'],
-            'Criteria' => [],
             'Query' => [],
         ];
 
@@ -58,7 +56,6 @@ class QueryParserTest extends BaseTest
     {
         $inputArray = [
             'Filter' => ['ContentTypeIdentifierCriterion' => 'article', 'ParentLocationIdCriterion' => 762],
-            'Criteria' => [],
             'Query' => [],
         ];
 
@@ -91,7 +88,6 @@ class QueryParserTest extends BaseTest
     {
         $inputArray = [
             'Query' => ['ContentTypeIdentifierCriterion' => 'article'],
-            'Criteria' => [],
             'Filter' => [],
         ];
 
@@ -116,7 +112,6 @@ class QueryParserTest extends BaseTest
     {
         $inputArray = [
             'Query' => ['ContentTypeIdentifierCriterion' => 'article', 'ParentLocationIdCriterion' => 762],
-            'Criteria' => [],
             'Filter' => [],
         ];
 


### PR DESCRIPTION
JIRA: [EZP-31183](https://jira.ez.no/browse/EZP-31183)

Using the `Criteria` element in REST input query (search view) payload has been deprecated since eZ Platform 1.6.

An example of deprecated usage:
``` xml
<ViewInput>
  <identifier>testCreateView</identifier>
  <Query>
    <Criteria>
      <ContentTypeIdentifierCriterion>folder</ContentTypeIdentifierCriterion>
    </Criteria>
    <limit>10</limit>
    <offset>0</offset>
  </Query>
</ViewInput> 
```
Instead of Criteria either Query or Filter should be used.

**TODO**:
- [x] See in which direction it explodes,
- [x] Fix integration test(s).