### PR TITLE
Changed LogicalOperator input criterion parser to be abstract

### DIFF
--- a/src/lib/Server/Input/Parser/Criterion/LogicalOperator.php
+++ b/src/lib/Server/Input/Parser/Criterion/LogicalOperator.php
@@ -12,22 +12,9 @@ use EzSystems\EzPlatformRest\Server\Input\Parser\Criterion;
 /**
  * Parser for LogicalOperator Criterion.
  */
-class LogicalOperator extends Criterion
+abstract class LogicalOperator extends Criterion
 {
-    /**
-     * Parses input structure to a Criterion object.
-     *
-     * @param array $data
-     * @param \EzSystems\EzPlatformRest\Input\ParsingDispatcher $parsingDispatcher
-     *
-     * @throws \EzSystems\EzPlatformRest\Exceptions\Parser
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator
-     */
-    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
-    {
-        throw new \Exception('@todo implement');
-    }
+    abstract public function parse(array $data, ParsingDispatcher $parsingDispatcher);
 
     /**
      * @param array $criteriaByType


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | TBD, discovered when working on [EZP-30806](https://jira.ez.no/browse/EZP-30806)
| **Type**| improvement
| **Target version** | eZ Platform `v3.0.0`
| **BC breaks**      | yes, with respect to ezpublish-kernel REST for eZ Platform `v2.5 LTS`
| **Tests pass**     | TBD
| **Doc needed**     | yes

Having a logical operator without a specific implementation doesn't make much sense. Instead of throwing an exception for the "parse" method that method is now abstract.

**TODO**:
- [ ] Create JIRA issue so release notes expose this change.
- [ ] See if anything needs to be aligned with this change.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
