### PR TITLE
[Composer] Added missing requirements for PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3",
+        "ext-dom": "*",
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "ext-simplexml": "*",
+        "ext-xmlwriter": "*",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "symfony/http-kernel": "^4.3",
         "symfony/dependency-injection": "^4.3",


### PR DESCRIPTION
| Question | Answer
| ------------ | ------------------
| **Type**  | bug

The package codebase uses the following PHP extensions:
 * ext-dom,
 * ext-json,
 * ext-libxml,
 * ext-simplexml,
 * ext-xmlwriter.

They need to be present in `composer.json` so an issue is reported when performing composer install. It's also a DX improvement when working with this package (PhpStorm reports missing extensions which is distracting).

**TODO**:
- [x] Add missing extensions to `composer.json`