### PR TITLE
Added totalCount attribute to REST ContentList response

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/ContentList.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/ContentList.php
@@ -35,6 +35,9 @@ class ContentList extends ValueObjectVisitor
         );
         $generator->endAttribute('href');
 
+        $generator->startAttribute('totalCount', $data->totalCount);
+        $generator->endAttribute('totalCount');
+
         $generator->startList('ContentInfo');
         foreach ($data->contents as $content) {
             $visitor->visitValueObject($content);

--- a/src/lib/Server/Values/ContentList.php
+++ b/src/lib/Server/Values/ContentList.php
@@ -21,12 +21,21 @@ class ContentList extends RestValue
     public $contents;
 
     /**
+     * Total items list count.
+     *
+     * @var int
+     */
+    public $totalCount;
+
+    /**
      * Construct.
      *
      * @param \EzSystems\EzPlatformRest\Server\Values\RestContent[] $contents
+     * @param int $totalCount
      */
-    public function __construct(array $contents)
+    public function __construct(array $contents, int $totalCount)
     {
         $this->contents = $contents;
+        $this->totalCount = $totalCount;
     }
 }

--- a/tests/lib/Server/Output/ValueObjectVisitor/ContentListTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/ContentListTest.php
@@ -127,7 +127,7 @@ class ContentListTest extends ValueObjectVisitorBaseTest
      *
      * @depends testContentListVisitsChildren
      */
-    public function testResultContainsTotalCountAttributes($result)
+    public function testResultContainsTotalCountAttributes(string $result): void
     {
         $this->assertXMLTag(
             [

--- a/tests/lib/Server/Output/ValueObjectVisitor/ContentListTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/ContentListTest.php
@@ -26,7 +26,7 @@ class ContentListTest extends ValueObjectVisitorBaseTest
 
         $generator->startDocument(null);
 
-        $contentList = new ContentList([]);
+        $contentList = new ContentList([], 0);
 
         $this->addRouteExpectation(
             'ezpublish_rest_redirectContent',
@@ -103,7 +103,8 @@ class ContentListTest extends ValueObjectVisitorBaseTest
             [
                 new RestContent(new ContentInfo()),
                 new RestContent(new ContentInfo()),
-            ]
+            ],
+            2
         );
 
         $this->getVisitorMock()->expects($this->exactly(2))
@@ -114,6 +115,30 @@ class ContentListTest extends ValueObjectVisitorBaseTest
             $this->getVisitorMock(),
             $generator,
             $contentList
+        );
+
+        return $generator->endDocument(null);
+    }
+
+    /**
+     * Test if result contains ContentList element attributes.
+     *
+     * @param string $result
+     *
+     * @depends testContentListVisitsChildren
+     */
+    public function testResultContainsTotalCountAttributes($result)
+    {
+        $this->assertXMLTag(
+            [
+                'tag' => 'ContentList',
+                'attributes' => [
+                    'totalCount' => 2,
+                ],
+            ],
+            $result,
+            'Invalid <ContentList> totalCount attribute.',
+            false
         );
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Used in [EZP-31316](https://jira.ez.no/browse/EZP-31316) for https://github.com/ezsystems/ezplatform-query-fieldtype/pull/20
| **Bug/Improvement**| improvement
| **New feature**    | yes
| **Target version** | `1.x`
| **BC breaks**      | yes (extra required argument for `ContentList`)
| **Tests pass**     | yes
| **Doc needed**     | yes (but not really, since that value object isn't exposed in the REST API)

Merged from https://github.com/ezsystems/ezpublish-kernel/pull/2936.

Adds a `totalCount` attribute to the REST response for `ContentList`. Used for pagination.

Note: since this value object is not used in the core REST API, it requires the query field type pull-request above to test it (or a custom REST route).
