### PR TITLE
EZP-31415: Impl. input parser for Sibling criterion

### DIFF
--- a/src/bundle/Resources/config/input_parsers.yml
+++ b/src/bundle/Resources/config/input_parsers.yml
@@ -524,6 +524,13 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
 
+    EzSystems\EzPlatformRest\Server\Input\Parser\Criterion\Sibling:
+        parent: ezpublish_rest.input.parser
+        arguments:
+            $locationService: "@ezpublish.api.service.location"
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Sibling }
+
     ezpublish_rest.input.parser.internal.sortclause.content_id:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'

--- a/src/lib/Server/Input/Parser/Criterion/Sibling.php
+++ b/src/lib/Server/Input/Parser/Criterion/Sibling.php
@@ -26,12 +26,12 @@ class Sibling extends BaseParser
 
     public function parse(array $data, ParsingDispatcher $parsingDispatcher): SiblingCriterion
     {
-        if (!array_key_exists('SiblingsCriterion', $data)) {
+        if (!array_key_exists('SiblingCriterion', $data)) {
             throw new Exceptions\Parser('Invalid <SiblingCriterion> format');
         }
 
         $location = $this->locationService->loadLocation(
-            (int)$data['SiblingsCriterion']
+            (int)$data['SiblingCriterion']
         );
 
         return SiblingCriterion::fromLocation($location);

--- a/src/lib/Server/Input/Parser/Criterion/Sibling.php
+++ b/src/lib/Server/Input/Parser/Criterion/Sibling.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformRest\Server\Input\Parser\Criterion;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Sibling as SiblingCriterion;
+use EzSystems\EzPlatformRest\Input\BaseParser;
+use EzSystems\EzPlatformRest\Input\ParsingDispatcher;
+use EzSystems\EzPlatformRest\Exceptions;
+
+class Sibling extends BaseParser
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): SiblingCriterion
+    {
+        if (!array_key_exists('SiblingsCriterion', $data)) {
+            throw new Exceptions\Parser('Invalid <SiblingCriterion> format');
+        }
+
+        $location = $this->locationService->loadLocation(
+            (int)$data['SiblingsCriterion']
+        );
+
+        return SiblingCriterion::fromLocation($location);
+    }
+}

--- a/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
@@ -58,7 +58,7 @@ final class SiblingTest extends BaseTest
         $this->expectExceptionMessage('Invalid <SiblingCriterion> format');
 
         $this->getParser()->parse([
-            /** Missing SiblingsCriterion key */
+        /** Missing SiblingsCriterion key */
         ], $this->getParsingDispatcherMock());
     }
 

--- a/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
@@ -58,7 +58,7 @@ final class SiblingTest extends BaseTest
         $this->expectExceptionMessage('Invalid <SiblingCriterion> format');
 
         $this->getParser()->parse([
-        /** Missing SiblingsCriterion key */
+        /** Missing SiblingCriterion key */
         ], $this->getParsingDispatcherMock());
     }
 

--- a/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
@@ -41,7 +41,7 @@ final class SiblingTest extends BaseTest
             ->willReturn($location);
 
         $actual = $this->getParser()->parse([
-            'SiblingsCriterion' => self::EXAMPLE_LOCATION_ID,
+            'SiblingCriterion' => self::EXAMPLE_LOCATION_ID,
         ], $this->getParsingDispatcherMock());
 
         $exepected = new SiblingCriterion(

--- a/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/SiblingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformRest\Tests\Server\Input\Parser\Criterion;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Sibling as SiblingCriterion;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use EzSystems\EzPlatformRest\Exceptions\Parser as ParserExpcetion;
+use EzSystems\EzPlatformRest\Server\Input\Parser\Criterion\Sibling as SiblingParser;
+use EzSystems\EzPlatformRest\Tests\Server\Input\Parser\BaseTest;
+
+final class SiblingTest extends BaseTest
+{
+    private const EXAMPLE_LOCATION_ID = 54;
+    private const EXAMPLE_PARENT_LOCATION_ID = 2;
+
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    protected function setUp(): void
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+    }
+
+    public function testParse(): void
+    {
+        $location = new Location([
+            'id' => self::EXAMPLE_LOCATION_ID,
+            'parentLocationId' => self::EXAMPLE_PARENT_LOCATION_ID,
+        ]);
+
+        $this->locationService
+            ->method('loadLocation')
+            ->with(self::EXAMPLE_LOCATION_ID)
+            ->willReturn($location);
+
+        $actual = $this->getParser()->parse([
+            'SiblingsCriterion' => self::EXAMPLE_LOCATION_ID,
+        ], $this->getParsingDispatcherMock());
+
+        $exepected = new SiblingCriterion(
+            self::EXAMPLE_LOCATION_ID,
+            self::EXAMPLE_PARENT_LOCATION_ID
+        );
+
+        $this->assertEquals($exepected, $actual);
+    }
+
+    public function testParseThrowsParserException(): void
+    {
+        $this->expectException(ParserExpcetion::class);
+        $this->expectExceptionMessage('Invalid <SiblingCriterion> format');
+
+        $this->getParser()->parse([
+            /** Missing SiblingsCriterion key */
+        ], $this->getParsingDispatcherMock());
+    }
+
+    protected function internalGetParser(): SiblingParser
+    {
+        return new SiblingParser($this->locationService);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31415](https://jira.ez.no/browse/EZP-31415)
| **Requires** | https://github.com/ezsystems/ezpublish-kernel/pull/2958 |
| **Type**| feature
| **Target version** |`v3.0.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

See https://github.com/ezsystems/ezpublish-kernel/pull/2958 for more details. Usage example:

```
{"SiblingCriterion": 54}
```

**TODO**:
- [x] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
