### PR TITLE
EZP-31501: Added missing ezsystems/doctrine-dbal-schema package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,10 @@
         "ezsystems/templated-uri-bundle": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16.0",
+        "phpunit/phpunit": "^8.5",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "nyholm/psr7": "^1.1",
         "symfony/http-client": "^5.0",


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31501
> Passing build: https://travis-ci.org/github/ezsystems/ezplatform-rest/builds/665053371

Since we decided to remove `minimum-stability` and `prefer-stable` from `composer.json` it's now impossible to install the package because of unresolved depencencies. This PR `ezsystems/doctrine-dbal-schema` package required by ezpublish-kernel.