### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "symfony/http-kernel": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/routing": "^5.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel`.

#### TODO
- [x] Wait for Travis