### PR TITLE
EZP-31680: Provided `languageCode` param to REST Views

### DIFF
--- a/src/lib/Server/Controller/Views.php
+++ b/src/lib/Server/Controller/Views.php
@@ -50,12 +50,21 @@ class Views extends Controller
             $method = 'findContent';
         }
 
+        $languageFilter = [
+            'languages' => null !== $viewInput->languageCode ? [$viewInput->languageCode] : Language::ALL,
+            'useAlwaysAvailable' => $viewInput->useAlwaysAvailable ?? true,
+        ];
+        $query = $viewInput->query->query;
+        if (!empty($query->value)) {
+            $languageFilter['excludeTranslationsFromAlwaysAvailable'] = false;
+        }
+
         return new Values\RestExecutedView(
             [
                 'identifier' => $viewInput->identifier,
                 'searchResults' => $this->searchService->$method(
                     $viewInput->query,
-                    ['languages' => Language::ALL]
+                    $languageFilter
                 ),
             ]
         );

--- a/src/lib/Server/Input/Parser/ViewInput.php
+++ b/src/lib/Server/Input/Parser/ViewInput.php
@@ -36,6 +36,10 @@ class ViewInput extends BaseParser
         }
         $restViewInput->identifier = $data['identifier'];
 
+        // language params
+        $restViewInput->languageCode = $data['languageCode'] ?? null;
+        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? null;
+
         // query
         if (!array_key_exists('Query', $data) || !is_array($data['Query'])) {
             throw new Exceptions\Parser('Missing <Query> attribute for <ViewInput>.');

--- a/src/lib/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/src/lib/Server/Input/Parser/ViewInputOneDotOne.php
@@ -36,6 +36,10 @@ class ViewInputOneDotOne extends CriterionParser
         }
         $restViewInput->identifier = $data['identifier'];
 
+        // language params
+        $restViewInput->languageCode = $data['languageCode'] ?? null;
+        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? null;
+
         // query
         if (array_key_exists('ContentQuery', $data) && is_array($data['ContentQuery'])) {
             $queryData = $data['ContentQuery'];

--- a/src/lib/Server/Values/RestViewInput.php
+++ b/src/lib/Server/Values/RestViewInput.php
@@ -26,4 +26,14 @@ class RestViewInput extends RestValue
      * @var string
      */
     public $identifier;
+
+    /**
+     * @var string|null
+     */
+    public $languageCode;
+
+    /**
+     * @var bool|null
+     */
+    public $useAlwaysAvailable;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31680](https://jira.ez.no/browse/EZP-31680)
| **Type**| improvement
| **Target version** | eZ Platform v3.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR is a direct continuation of https://github.com/ezsystems/ezpublish-kernel/pull/3043

REST views will now utilize `languageCode` param in order to find `Content` in the chosen language.

Related `admin-ui` PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1407

Side note: Rest visitor is not able to receive any language info as it is created out of `Location` object - https://github.com/ezsystems/ezplatform-rest/blob/master/src/lib/Server/Output/ValueObjectVisitor/RestContent.php#L41 It would be great to force a language on this line, but I don't think its really possible right now without some heavy alterations.

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
