### PR TITLE
EZP-31776: Provided 'null' as Location in RestExecutedView if unavailable

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -6,6 +6,8 @@
  */
 namespace EzSystems\EzPlatformRest\Server\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content as ApiValues;
 use EzSystems\EzPlatformRest\Exceptions;
 use EzSystems\EzPlatformRest\Output\ValueObjectVisitor;
@@ -113,9 +115,16 @@ class RestExecutedView extends ValueObjectVisitor
             if ($searchHit->valueObject instanceof ApiValues\Content) {
                 /** @var \eZ\Publish\API\Repository\Values\Content\Content $searchHit->valueObject */
                 $contentInfo = $searchHit->valueObject->contentInfo;
+
+                try {
+                    $mainLocation = $this->locationService->loadLocation($contentInfo->mainLocationId);
+                } catch (NotFoundException | UnauthorizedException $e) {
+                    $mainLocation = null;
+                }
+
                 $valueObject = new RestContentValue(
                     $contentInfo,
-                    $this->locationService->loadLocation($contentInfo->mainLocationId),
+                    $mainLocation,
                     $searchHit->valueObject,
                     $searchHit->valueObject->getContentType(),
                     $this->contentService->loadRelations($searchHit->valueObject->getVersionInfo())


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31776](https://jira.ez.no/browse/EZP-31776)
| **Type**| bug
| **Target version** | eZ Platform v3.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When loading Location via REST main Location might not be accessible for the end-user due to permissions which results in Unauthorized Exception even though the user can have access to different Locations of this Relation.

This PR is a direct follow-up on the v2.5 PR: https://github.com/ezsystems/ezpublish-kernel/pull/3055

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
