### PR TITLE
EZP-31039: Skip requirement of sort params when updating Location via REST

### DIFF
--- a/src/lib/Server/Input/Parser/LocationUpdate.php
+++ b/src/lib/Server/Input/Parser/LocationUpdate.php
@@ -9,7 +9,6 @@ namespace EzSystems\EzPlatformRest\Server\Input\Parser;
 use EzSystems\EzPlatformRest\Input\BaseParser;
 use EzSystems\EzPlatformRest\Input\ParsingDispatcher;
 use EzSystems\EzPlatformRest\Input\ParserTools;
-use EzSystems\EzPlatformRest\Exceptions;
 use eZ\Publish\API\Repository\LocationService;
 use EzSystems\EzPlatformRest\Server\Values\RestLocationUpdateStruct;
 
@@ -69,17 +68,13 @@ class LocationUpdate extends BaseParser
             $hidden = $this->parserTools->parseBooleanValue($data['hidden']);
         }
 
-        if (!array_key_exists('sortField', $data)) {
-            throw new Exceptions\Parser("Missing 'sortField' element for LocationUpdate.");
+        if (array_key_exists('sortField', $data)) {
+            $locationUpdateStruct->sortField = $this->parserTools->parseDefaultSortField($data['sortField']);
         }
 
-        $locationUpdateStruct->sortField = $this->parserTools->parseDefaultSortField($data['sortField']);
-
-        if (!array_key_exists('sortOrder', $data)) {
-            throw new Exceptions\Parser("Missing 'sortOrder' element for LocationUpdate.");
+        if (array_key_exists('sortOrder', $data)) {
+            $locationUpdateStruct->sortOrder = $this->parserTools->parseDefaultSortOrder($data['sortOrder']);
         }
-
-        $locationUpdateStruct->sortOrder = $this->parserTools->parseDefaultSortOrder($data['sortOrder']);
 
         return new RestLocationUpdateStruct($locationUpdateStruct, $hidden);
     }

--- a/tests/lib/Server/Input/Parser/LocationUpdateTest.php
+++ b/tests/lib/Server/Input/Parser/LocationUpdateTest.php
@@ -74,12 +74,10 @@ class LocationUpdateTest extends BaseTest
     }
 
     /**
-     * Test LocationUpdate parser throwing exception on missing sort field.
+     * Test LocationUpdate parser with missing sort field.
      */
-    public function testParseExceptionOnMissingSortField()
+    public function testParseWithMissingSortField()
     {
-        $this->expectException('EzSystems\EzPlatformRest\Exceptions\Parser');
-        $this->expectExceptionMessage('Missing \'sortField\' element for LocationUpdate.');
         $inputArray = [
             'priority' => 0,
             'remoteId' => 'remote-id',
@@ -87,16 +85,28 @@ class LocationUpdateTest extends BaseTest
         ];
 
         $locationUpdate = $this->getParser();
-        $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+        $result = $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertInstanceOf(
+            RestLocationUpdateStruct::class,
+            $result
+        );
+
+        $this->assertInstanceOf(
+            LocationUpdateStruct::class,
+            $result->locationUpdateStruct
+        );
+
+        $this->assertNull(
+            $result->locationUpdateStruct->sortField
+        );
     }
 
     /**
-     * Test LocationUpdate parser throwing exception on missing sort order.
+     * Test LocationUpdate parser with missing sort order.
      */
-    public function testParseExceptionOnMissingSortOrder()
+    public function testParseWithMissingSortOrder()
     {
-        $this->expectException(Parser::class);
-        $this->expectExceptionMessage('Missing \'sortOrder\' element for LocationUpdate.');
         $inputArray = [
             'priority' => 0,
             'remoteId' => 'remote-id',
@@ -104,7 +114,21 @@ class LocationUpdateTest extends BaseTest
         ];
 
         $locationUpdate = $this->getParser();
-        $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+        $result = $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertInstanceOf(
+            RestLocationUpdateStruct::class,
+            $result
+        );
+
+        $this->assertInstanceOf(
+            LocationUpdateStruct::class,
+            $result->locationUpdateStruct
+        );
+
+        $this->assertNull(
+            $result->locationUpdateStruct->sortOrder
+        );
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31039](https://jira.ez.no/browse/EZP-31039)
| **Type**| improvement
| **Target version** | v3.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`updateLocation` API method doesn't require the existence of sort params in `LocationUpdateStruct` (it will use params already stored in the Location itself), we can remove them when parsing REST data.

Related `ezplatform-admin-ui` PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1643

Parent `ezpublish-kernel` PR: https://github.com/ezsystems/ezpublish-kernel/pull/3071

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
