### PR TITLE
EZP-32107: Impl. visitor for Score sort clause

### DIFF
--- a/src/bundle/Resources/config/input_parsers.yml
+++ b/src/bundle/Resources/config/input_parsers.yml
@@ -660,6 +660,15 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionName }
 
+    ezpublish_rest.input.parser.internal.sortclause.score:
+        parent: ezpublish_rest.input.parser
+        class: 'EzSystems\EzPlatformRest\Server\Input\Parser\SortClause\DataKeyValueObjectClass'
+        arguments:
+            - 'Score'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Score'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Score }
+
     ezpublish_rest.input.parser.internal.sortclause.Field:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.field.class%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32107](https://jira.ez.no/browse/EZP-32107)
| **Requires** | https://github.com/ezsystems/ezplatform-kernel/pull/130
| **Type**| feature
| **Target version** | `v3.3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Example request:

```http
POST http://localhost:8000/api/ezp/v2/views
Accept: application/json
Content-Type: application/vnd.ez.api.ViewInput+json; version=1.1
X-CSRF-Token: {{CSRF_TOKEN}}

{
  "ViewInput": {
    "identifier": "view_with_sort_score",
    "ContentQuery": {
      "limit": "10",
      "offset": "0",
      "Query": {
        "FullTextCriterion": "Ibexa"
      },
      "SortClauses": {
        "Score": "descending"
      }
    }
  }
}
```

**TODO**:
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
