### PR TITLE
EZP-32128: Variations hrefs no longer generated for removed image asset relation

### DIFF
--- a/src/lib/FieldTypeProcessor/ImageAssetFieldTypeProcessor.php
+++ b/src/lib/FieldTypeProcessor/ImageAssetFieldTypeProcessor.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformRest\FieldTypeProcessor;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use EzSystems\EzPlatformRest\FieldTypeProcessor;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -48,7 +49,11 @@ class ImageAssetFieldTypeProcessor extends FieldTypeProcessor
             return $outgoingValueHash;
         }
 
-        $imageContent = $this->contentService->loadContent((int) $outgoingValueHash['destinationContentId']);
+        try {
+            $imageContent = $this->contentService->loadContent((int) $outgoingValueHash['destinationContentId']);
+        } catch (NotFoundException $e) {
+            return $outgoingValueHash;
+        }
 
         $field = $imageContent->getField($this->configMappings['content_field_identifier']);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32128](https://jira.ez.no/browse/EZP-32128)
| **Type**| bug
| **Target version** | `v3.2`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

**TODO**:
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
