### PR TITLE
EZP-32215: Made `ezpublish_rest.session_authenticator` dependency optional

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -243,10 +243,10 @@ services:
         class: EzSystems\EzPlatformRest\Server\Controller\SessionController
         parent: ezpublish_rest.controller.base
         arguments:
-            - "@ezpublish_rest.session_authenticator"
             - "%ezpublish_rest.csrf_token_intention%"
             - '@eZ\Publish\API\Repository\PermissionResolver'
             - '@ezpublish.api.service.user'
+            - "@?ezpublish_rest.session_authenticator"
             - "@?ezpublish_rest.security.csrf.token_manager"
         tags: [controller.service_arguments]
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32215](https://jira.ez.no/browse/EZP-32215)
| **Type**| bug
| **Target version** | eZ Platform `v3.3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When installing the app with flex we are not able to override security.yaml file which breaks compiling the container. `ezpublish_rest.controller.session` has a dependency on `ezpublish_rest.session_authenticator` which isn't created unless `ezpublish_rest_session` is configured for a firewall.

I made the dependency optional. When you access affected endpoint it will throw an Exception explaining invalid security configuration. 

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
