### PR TITLE
EZP-32340: Deprecated ezpublish_rest.field_type_processor in favour of ibexa.rest.field_type.processor

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
@@ -6,12 +6,17 @@
  */
 namespace EzSystems\EzPlatformRestBundle\DependencyInjection\Compiler;
 
+use eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
+use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class FieldTypeProcessorPass implements CompilerPassInterface
 {
+    public const FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ezplatform.field_type.rest.processor';
+    public const DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ezpublish_rest.field_type_processor';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish_rest.field_type_processor_registry')) {
@@ -20,15 +25,28 @@ class FieldTypeProcessorPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('ezpublish_rest.field_type_processor_registry');
 
-        foreach ($container->findTaggedServiceIds('ezpublish_rest.field_type_processor') as $id => $attributes) {
+        $iterator = new BackwardCompatibleIterator(
+            $container,
+            self::FIELD_TYPE_PROCESSOR_SERVICE_TAG,
+            self::DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG
+        );
+
+        foreach ($iterator as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
-                    throw new \LogicException('The ezpublish_rest.field_type_processor service tag needs an "alias" attribute to identify the Field Type.');
+                    throw new LogicException(
+                        sprintf(
+                            'Service "%s" tagged with "%s" or "%s" needs an "alias" attribute to identify the Field Type',
+                            $serviceId,
+                            self::FIELD_TYPE_PROCESSOR_SERVICE_TAG,
+                            self::DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG
+                        )
+                    );
                 }
 
                 $definition->addMethodCall(
                     'registerProcessor',
-                    [$attribute['alias'], new Reference($id)]
+                    [$attribute['alias'], new Reference($serviceId)]
                 );
             }
         }

--- a/src/bundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FieldTypeProcessorPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ezplatform.field_type.rest.processor';
+    public const FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ibexa.rest.field_type.processor';
     public const DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ezpublish_rest.field_type_processor';
 
     public function process(ContainerBuilder $container)

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -307,35 +307,35 @@ services:
         arguments:
             - "@router"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezimage }
+            - { name: ibexa.rest.field_type.processor, alias: ezimage }
 
     EzSystems\EzPlatformRest\FieldTypeProcessor\ImageAssetFieldTypeProcessor:
         factory: ["@ezpublish_rest.factory", getImageAssetFieldTypeProcessor]
         arguments:
             - "@router"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezimageasset }
+            - { name: ibexa.rest.field_type.processor, alias: ezimageasset }
 
     ezpublish_rest.field_type_processor.ezdatetime:
         class: "%ezpublish_rest.field_type_processor.ezdatetime.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezdatetime }
+            - { name: ibexa.rest.field_type.processor, alias: ezdatetime }
 
     ezpublish_rest.field_type_processor.ezdate:
         class: "%ezpublish_rest.field_type_processor.ezdate.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezdate }
+            - { name: ibexa.rest.field_type.processor, alias: ezdate }
 
     ezpublish_rest.field_type_processor.ezmedia:
         class: "%ezpublish_rest.field_type_processor.ezmedia.class%"
         factory: ["@ezpublish_rest.factory", getMediaFieldTypeProcessor]
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezmedia }
+            - { name: ibexa.rest.field_type.processor, alias: ezmedia }
 
     ezpublish_rest.field_type_processor.ezobjectrelationlist:
         class: "%ezpublish_rest.field_type_processor.ezobjectrelationlist.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezobjectrelationlist }
+            - { name: ibexa.rest.field_type.processor, alias: ezobjectrelationlist }
         calls:
             - [setRouter, ["@router"]]
             - [setLocationService, ["@ezpublish.api.service.location"]]
@@ -343,7 +343,7 @@ services:
     ezpublish_rest.field_type_processor.ezobjectrelation:
         class: "%ezpublish_rest.field_type_processor.ezobjectrelation.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezobjectrelation }
+            - { name: ibexa.rest.field_type.processor, alias: ezobjectrelation }
         calls:
             - [setRouter, ["@router"]]
             - [setLocationService, ["@ezpublish.api.service.location"]]
@@ -351,7 +351,7 @@ services:
     ezpublish_rest.field_type_processor.eztime:
         class: "%ezpublish_rest.field_type_processor.eztime.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: eztime }
+            - { name: ibexa.rest.field_type.processor, alias: eztime }
 
     ezpublish_rest.field_type_processor.ezbinaryfile:
         class: "%ezpublish_rest.field_type_processor.ezbinaryfile.class%"
@@ -359,22 +359,22 @@ services:
         arguments:
             - "@ezpublish.core.io.default_url_decorator"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezbinaryfile }
+            - { name: ibexa.rest.field_type.processor, alias: ezbinaryfile }
 
     ezpublish_rest.field_type_processor.ezfloat:
         class: "%ezpublish_rest.field_type_processor.ezfloat.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezfloat }
+            - { name: ibexa.rest.field_type.processor, alias: ezfloat }
 
     ezpublish_rest.field_type_processor.ezstring:
         class: "%ezpublish_rest.field_type_processor.ezstring.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezstring }
+            - { name: ibexa.rest.field_type.processor, alias: ezstring }
 
     ezpublish_rest.field_type_processor.ezuser:
         class: "%ezpublish_rest.field_type_processor.ezuser.class%"
         tags:
-            - { name: ezpublish_rest.field_type_processor, alias: ezuser }
+            - { name: ibexa.rest.field_type.processor, alias: ezuser }
 
     ### OUTPUT
 

--- a/tests/bundle/DependencyInjection/Compiler/FieldTypeProcessorPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/FieldTypeProcessorPassTest.php
@@ -14,10 +14,13 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FieldTypeProcessorPassTest extends TestCase
 {
-    public function testProcess()
+    /**
+     * @dataProvider dataProviderForProcess
+     */
+    public function testProcess(string $tag): void
     {
         $processorDefinition = new Definition();
-        $processorDefinition->addTag('ezpublish_rest.field_type_processor', ['alias' => 'test']);
+        $processorDefinition->addTag($tag, ['alias' => 'test']);
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions(
@@ -35,5 +38,11 @@ class FieldTypeProcessorPassTest extends TestCase
         self::assertEquals('registerProcessor', $dispatcherMethodCalls[0][0], "Failed asserting that called method is 'addVisitor'");
         self::assertInstanceOf(Reference::class, $dispatcherMethodCalls[0][1][1], 'Failed asserting that method call is to a Reference object');
         self::assertEquals('ezpublish_rest.field_type_processor.test', $dispatcherMethodCalls[0][1][1]->__toString(), "Failed asserting that Referenced service is 'ezpublish_rest.output.value_object_visitor.test'");
+    }
+
+    public function dataProviderForProcess(): iterable
+    {
+        yield [FieldTypeProcessorPass::FIELD_TYPE_PROCESSOR_SERVICE_TAG];
+        yield [FieldTypeProcessorPass::DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG];
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32340](https://jira.ez.no/browse/EZP-32340)
| **Type**| improvement
| **Target version** | `3.2`+
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Deprecated `ezpublish_rest.field_type_processor` in favour of `ezplatform.field_type.rest.processor`.

**TODO**:
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
