### PR TITLE
Fixed discrepancies between phpdoc / service config and actual declarations

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -435,9 +435,6 @@ services:
         arguments:
             - "@ezpublish_rest.input.parsing_dispatcher"
             - []
-            - "@ezpublish_rest.request_parser"
-            - "@ezpublish_rest.parser_tools"
-            - "@ezpublish_rest.field_type_parser"
 
     ezpublish_rest.input.parsing_dispatcher:
         class: "%ezpublish_rest.input.parsing_dispatcher.class%"

--- a/src/lib/Input/Dispatcher.php
+++ b/src/lib/Input/Dispatcher.php
@@ -41,7 +41,7 @@ class Dispatcher
      * @param \EzSystems\EzPlatformRest\Input\ParsingDispatcher $parsingDispatcher
      * @param \EzSystems\EzPlatformRest\Input\Handler[] $handlers
      */
-    public function __construct(ParsingDispatcher $parsingDispatcher, iterable $handlers = [])
+    public function __construct(ParsingDispatcher $parsingDispatcher, array $handlers = [])
     {
         $this->parsingDispatcher = $parsingDispatcher;
         foreach ($handlers as $type => $handler) {

--- a/src/lib/Input/Dispatcher.php
+++ b/src/lib/Input/Dispatcher.php
@@ -26,7 +26,7 @@ class Dispatcher
      *  )
      * </code>
      *
-     * @var array
+     * @var \EzSystems\EzPlatformRest\Input\Handler[]
      */
     protected $handlers = [];
 
@@ -39,9 +39,9 @@ class Dispatcher
      * Construct from optional parsers array.
      *
      * @param \EzSystems\EzPlatformRest\Input\ParsingDispatcher $parsingDispatcher
-     * @param array $handlers
+     * @param \EzSystems\EzPlatformRest\Input\Handler[] $handlers
      */
-    public function __construct(ParsingDispatcher $parsingDispatcher, array $handlers = [])
+    public function __construct(ParsingDispatcher $parsingDispatcher, iterable $handlers = [])
     {
         $this->parsingDispatcher = $parsingDispatcher;
         foreach ($handlers as $type => $handler) {

--- a/src/lib/Input/ParsingDispatcher.php
+++ b/src/lib/Input/ParsingDispatcher.php
@@ -84,7 +84,7 @@ class ParsingDispatcher
      *
      * @param string $mediaType Ex: text/html; version=1.1
      *
-     * @return string An array with the mediatype string, stripped from the version, and the version (1.0 by default)
+     * @return array An array with the mediatype string, stripped from the version, and the version (1.0 by default)
      */
     protected function parseMediaTypeVersion($mediaType)
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | none
| **Type**| improvement
| **Target version** | v3.3
| **BC breaks**      | no
| **Doc needed**     | no

This PR fixes issues discovered when working on ez commerce rest.
 * phpdoc fixes for wrong return types, more specific argument types
 * services declaration injects more services than are declared in constructor (potential BC break here?)

Not included in PR, but available - `InputHandlerPass` can be removed and replaced with `!tagged_iterator` indexed by `format` tag attribute (would change / delay the exception).

- [ ] ~Implement tests~.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
