### PR TITLE
Fixed HTTP status codes returned for Symfony built-in exceptions for REST API

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/ContentFieldValidationException.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/ContentFieldValidationException.php
@@ -33,7 +33,10 @@ class ContentFieldValidationException extends BadRequestException
         $generator->startValueElement('errorCode', $statusCode);
         $generator->endValueElement('errorCode');
 
-        $generator->startValueElement('errorMessage', $this->httpStatusCodes[$statusCode]);
+        $generator->startValueElement(
+            'errorMessage',
+            static::$httpStatusCodes[$statusCode] ?? static::$httpStatusCodes[500]
+        );
         $generator->endValueElement('errorMessage');
 
         $generator->startValueElement('errorDescription', $data->getMessage());


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-84](https://issues.ibexa.co/browse/IBX-84)
| **Type**| bug
| **Target version** | `v2.5`
| **BC breaks**      | no
| **Tests pass**     | -
| **Doc needed**     | no

This PR makes return codes for Symfony exceptions (for example, missing routes) match their expectations.

Without this, missing routes respond with HTTP 500 Internal Server Error.

Additionally, error messages for http codes are made static, so they are not duplicated for each subsequent inheriting Visitor.

**TODO**:
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
