### PR TITLE
IBX-833: As a Developer I want to configure CSRF validation in REST endpoints

### DIFF
--- a/src/bundle/EventListener/CsrfListener.php
+++ b/src/bundle/EventListener/CsrfListener.php
@@ -104,6 +104,10 @@ class CsrfListener implements EventSubscriberInterface
             return;
         }
 
+        if (!$event->getRequest()->attributes->getBoolean('csrf_protection', true)) {
+            return;
+        }
+
         if (!$this->checkCsrfToken($event->getRequest())) {
             throw new UnauthorizedException(
                 'Missing or invalid CSRF token',
@@ -143,6 +147,8 @@ class CsrfListener implements EventSubscriberInterface
      * @param string $route
      *
      * @return bool
+     *
+     * @deprecated since Ibexa DXP 3.3.7. Add csrf_protection: false attribute to route definition instead.
      */
     protected function isSessionRoute($route)
     {

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -1118,18 +1118,21 @@ ezpublish_rest_createSession:
     path: /user/sessions
     defaults:
         _controller: ezpublish_rest.controller.session:createSessionAction
+        csrf_protection: false
     methods: [POST]
 
 ezpublish_rest_deleteSession:
     path: /user/sessions/{sessionId}
     defaults:
         _controller: ezpublish_rest.controller.session:deleteSessionAction
+        csrf_protection: false
     methods: [DELETE]
 
 ezpublish_rest_refreshSession:
     path: /user/sessions/{sessionId}/refresh
     defaults:
         _controller: ezpublish_rest.controller.session:refreshSessionAction
+        csrf_protection: false
     methods: [POST]
 
 

--- a/tests/bundle/EventListener/CsrfListenerTest.php
+++ b/tests/bundle/EventListener/CsrfListenerTest.php
@@ -137,6 +137,15 @@ class CsrfListenerTest extends EventListenerTest
         ];
     }
 
+    public function testSkipCsrfProtection(): void
+    {
+        $this->enableCsrfProtection = false;
+        $this->csrfTokenHeaderValue = null;
+
+        $listener = $this->getEventListener();
+        $listener->onKernelRequest($this->getEvent());
+    }
+
     public function testNoHeader()
     {
         $this->expectException(UnauthorizedException::class);

--- a/tests/bundle/EventListener/EventListenerTest.php
+++ b/tests/bundle/EventListener/EventListenerTest.php
@@ -34,6 +34,8 @@ abstract class EventListenerTest extends TestCase
 
     protected $requestMethod = false;
 
+    protected $enableCsrfProtection = true;
+
     /**
      * @dataProvider provideExpectedSubscribedEventTypes
      */
@@ -87,6 +89,11 @@ abstract class EventListenerTest extends TestCase
                 ->method('get')
                 ->with('is_rest_request')
                 ->willReturn($this->isRestRequest);
+
+            $this->requestAttributesMock
+                ->method('getBoolean')
+                ->with('csrf_protection', true)
+                ->willReturn($this->enableCsrfProtection);
         }
 
         return $this->requestAttributesMock;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-833](https://jira.ez.no/browse/IBX-833)
| **Type**| improvement
| **Target version** | 3.3.7+
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Allow to configure CSRF validation in REST endpoints using 

```yaml
csrf_protection: false
```

attribute in route definition.

Currently to achive the same efect `\EzSystems\EzPlatformRestBundle\EventListener\CsrfListener::isSessionRoute` needs to be overriden:

```php
class CsrfListener implements EventSubscriberInterface
   # ...
    protected function isSessionRoute($route)
    {
        return in_array(
            $route,
            ['ezpublish_rest_createSession', 'ezpublish_rest_refreshSession', 'ezpublish_rest_deleteSession']
        );
    }
    # ...
}
```

Example use cases:
* Forgot password implementation via REST

**TODO**:
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
