### PR TITLE
IBX-984: Replaced hautelook/templated-uri-bundle with Ibexa fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/expression-language": "^5.3",
         "symfony/form": "^5.3",
         "symfony/security-bundle": "^5.3",
-        "hautelook/templated-uri-bundle": "^3.2",
+        "ibexa/templated-uri-bundle": "^3.2",
         "lexik/jwt-authentication-bundle": "^2.8"
     },
     "require-dev": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-984](https://issues.ibexa.co/browse/IBX-984)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3`+
| **BC breaks**                          | yes

The `hautelook/templated-uri-bundle` package disappeared from open source ecosystem without any explanation, so we had to fork it and use our own for instead.