### PR TITLE
Skipped PHP internal errors serialization

### DIFF
--- a/src/lib/Output/ValueObjectVisitorDispatcher.php
+++ b/src/lib/Output/ValueObjectVisitorDispatcher.php
@@ -6,6 +6,8 @@
  */
 namespace EzSystems\EzPlatformRest\Output;
 
+use Error;
+
 /**
  * Dispatches value objects to a visitor depending on the class name.
  */
@@ -55,6 +57,11 @@ class ValueObjectVisitorDispatcher
      */
     public function visit($data)
     {
+        if ($data instanceof Error) {
+            // Skip internal PHP errors serialization
+            throw $data;
+        }
+
         if (!is_object($data)) {
             throw new Exceptions\InvalidTypeException($data);
         }

--- a/tests/lib/Output/ValueObjectVisitorDispatcherTest.php
+++ b/tests/lib/Output/ValueObjectVisitorDispatcherTest.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformRest\Tests\Output;
 
+use Error;
 use EzSystems\EzPlatformRest;
 use EzSystems\EzPlatformRest\Output\Exceptions\InvalidTypeException;
 use EzSystems\EzPlatformRest\Output\Exceptions\NoVisitorFoundException;
@@ -99,6 +100,14 @@ class ValueObjectVisitorDispatcherTest extends TestCase
             ->with($this->getOutputVisitorMock(), $this->getOutputGeneratorMock(), $data);
 
         $dispatcher->visit($data);
+    }
+
+    public function testVisitError(): void
+    {
+        $this->expectException(Error::class);
+
+        $dispatcher = $this->getValueObjectDispatcher();
+        $dispatcher->visit($this->createMock(Error::class));
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Type**| bug/improvement
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently `\EzSystems\EzPlatformRest\Output\ValueObjectVisitorDispatcher` hides PHP internal errors under `\EzSystems\EzPlatformRest\Output\Exceptions\NoVisitorFoundException` exception and it's not possible from developer POV to check what happend without breakpoint. 

**TODO**:
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
