### PR TITLE
Fixed autoload for test classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,7 @@
             "EzSystems\\EzPlatformRestBundle\\": "src/bundle/",
             "EzSystems\\EzPlatformRest\\": "src/lib/",
             "Ibexa\\Bundle\\Rest\\": "src/bundle/",
-            "Ibexa\\Rest\\": "src/lib/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "Ibexa\\Rest\\": "src/lib/",
             "EzSystems\\EzPlatformRestBundle\\Tests\\": "tests/bundle/",
             "EzSystems\\EzPlatformRest\\Tests\\": "tests/lib/",
             "Ibexa\\Tests\\Rest\\": "tests/lib/",


### PR DESCRIPTION
Fixed autoload for test classes.

`EzSystems\EzPlatformRestBundle\Tests\Functional\TestCase` is used by `\EzSystems\Tests\EzPlatformRichText\Configuration\Provider\BaseProviderTestCase`, therefore needs to be accessible by composer autoload.

