### PR TITLE
IBX-1507: Provided additional arguments for Location Visitor

### DIFF
--- a/src/bundle/Resources/config/value_object_visitors.yml
+++ b/src/bundle/Resources/config/value_object_visitors.yml
@@ -599,8 +599,8 @@ services:
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Location }
         arguments:
-            - "@ezpublish.api.service.location"
-            - "@ezpublish.api.service.content"
+            $locationService: '@ezpublish.api.service.location'
+            $contentService: '@ezpublish.api.service.content'
 
     ezpublish_rest.output.value_object_visitor.LocationList:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/src/bundle/Resources/config/value_object_visitors.yml
+++ b/src/bundle/Resources/config/value_object_visitors.yml
@@ -598,7 +598,9 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.Location.class%"
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Location }
-        arguments: ["@ezpublish.api.service.location"]
+        arguments:
+            - "@ezpublish.api.service.location"
+            - "@ezpublish.api.service.content"
 
     ezpublish_rest.output.value_object_visitor.LocationList:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/src/lib/Server/Output/ValueObjectVisitor/Location.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/Location.php
@@ -6,7 +6,10 @@
  */
 namespace EzSystems\EzPlatformRest\Server\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\ContentService;
 use EzSystems\EzPlatformRest\Output\ValueObjectVisitor;
 use EzSystems\EzPlatformRest\Output\Generator;
 use EzSystems\EzPlatformRest\Output\Visitor;
@@ -23,9 +26,15 @@ class Location extends ValueObjectVisitor
      */
     private $locationService;
 
-    public function __construct(LocationService $locationService)
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
+    private $contentService;
+
+    public function __construct(LocationService $locationService, ContentService $contentService)
     {
         $this->locationService = $locationService;
+        $this->contentService = $contentService;
     }
 
     /**
@@ -147,7 +156,27 @@ class Location extends ValueObjectVisitor
             )
         );
         $generator->endAttribute('href');
-        $visitor->visitValueObject(new RestContentValue($location->contentInfo));
+
+        $content = $location->getContent();
+        $contentInfo = $location->contentInfo;
+
+        try {
+            $mainLocation = $contentInfo->mainLocationId === $location->id
+                ? $location
+                : $this->locationService->loadLocation($contentInfo->mainLocationId);
+        } catch (NotFoundException | UnauthorizedException $e) {
+            $mainLocation = null;
+        }
+
+        $visitor->visitValueObject(new RestContentValue(
+                $contentInfo,
+                $mainLocation,
+                $content,
+                $content->getContentType(),
+                $this->contentService->loadRelations($content->getVersionInfo())
+            )
+        );
+
         $generator->endObjectElement('ContentInfo');
     }
 }

--- a/src/lib/Server/Output/ValueObjectVisitor/Location.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/Location.php
@@ -6,7 +6,6 @@
  */
 namespace EzSystems\EzPlatformRest\Server\Output\ValueObjectVisitor;
 
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\ContentService;
@@ -21,14 +20,10 @@ use eZ\Publish\API\Repository\Values\Content\Location as LocationValue;
  */
 class Location extends ValueObjectVisitor
 {
-    /**
-     * @var \eZ\Publish\API\Repository\LocationService
-     */
+    /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
-    /**
-     * @var \eZ\Publish\API\Repository\ContentService
-     */
+    /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
     public function __construct(LocationService $locationService, ContentService $contentService)
@@ -164,7 +159,7 @@ class Location extends ValueObjectVisitor
             $mainLocation = $contentInfo->mainLocationId === $location->id
                 ? $location
                 : $this->locationService->loadLocation($contentInfo->mainLocationId);
-        } catch (NotFoundException | UnauthorizedException $e) {
+        } catch (UnauthorizedException $e) {
             $mainLocation = null;
         }
 

--- a/tests/bundle/Functional/SearchView/SearchViewTest.php
+++ b/tests/bundle/Functional/SearchView/SearchViewTest.php
@@ -74,6 +74,40 @@ XML;
         self::assertEquals($expectedCount, $this->getQueryResultsCount('xml', $body));
     }
 
+    public function testLocationsByIdQueryContainsCurrentVersionObject(): void
+    {
+        $body = <<< JSON
+{
+    "ViewInput": {
+        "identifier": "locations-by-id",
+        "public": "false",
+        "LocationQuery": {
+            "Filter": {
+                "LocationIdCriterion": "2"
+            },
+            "limit": "10",
+            "offset": "0"
+        }
+    }
+}
+JSON;
+
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/views',
+            'ViewInput+json; version=1.1',
+            'View+json',
+            $body
+        );
+
+        $response = $this->sendHttpRequest($request);
+        $jsonResponse = json_decode($response->getBody()->getContents());
+
+        $content = $jsonResponse->View->Result->searchHits->searchHit[0]->value->Location->ContentInfo->Content;
+
+        self::assertIsObject($content->CurrentVersion->Version);
+    }
+
     /**
      * Covers POST with LocationQuery Logic on /api/ezp/v2/views using payload in the JSON format.
      *

--- a/tests/bundle/Functional/SearchView/SearchViewTest.php
+++ b/tests/bundle/Functional/SearchView/SearchViewTest.php
@@ -76,21 +76,21 @@ XML;
 
     public function testLocationsByIdQueryContainsCurrentVersionObject(): void
     {
-        $body = <<< JSON
-{
-    "ViewInput": {
-        "identifier": "locations-by-id",
-        "public": "false",
-        "LocationQuery": {
-            "Filter": {
-                "LocationIdCriterion": "2"
-            },
-            "limit": "10",
-            "offset": "0"
+        $body = <<<JSON
+        {
+            "ViewInput": {
+                "identifier": "locations-by-id",
+                "public": "false",
+                "LocationQuery": {
+                    "Filter": {
+                        "LocationIdCriterion": "2"
+                    },
+                    "limit": "10",
+                    "offset": "0"
+                }
+            }
         }
-    }
-}
-JSON;
+        JSON;
 
         $request = $this->createHttpRequest(
             'POST',
@@ -101,11 +101,11 @@ JSON;
         );
 
         $response = $this->sendHttpRequest($request);
-        $jsonResponse = json_decode($response->getBody()->getContents());
+        $jsonResponse = json_decode($response->getBody()->getContents(), true);
 
-        $content = $jsonResponse->View->Result->searchHits->searchHit[0]->value->Location->ContentInfo->Content;
+        $content = $jsonResponse['View']['Result']['searchHits']['searchHit'][0]['value']['Location']['ContentInfo']['Content'];
 
-        self::assertIsObject($content->CurrentVersion->Version);
+        self::assertTrue(isset($content['CurrentVersion']['Version']));
     }
 
     /**

--- a/tests/bundle/Functional/SearchView/SearchViewTest.php
+++ b/tests/bundle/Functional/SearchView/SearchViewTest.php
@@ -101,11 +101,11 @@ XML;
         );
 
         $response = $this->sendHttpRequest($request);
-        $jsonResponse = json_decode($response->getBody()->getContents(), true);
+        $jsonResponse = json_decode($response->getBody()->getContents());
 
-        $content = $jsonResponse['View']['Result']['searchHits']['searchHit'][0]['value']['Location']['ContentInfo']['Content'];
+        $content = $jsonResponse->View->Result->searchHits->searchHit[0]->value->Location->ContentInfo->Content;
 
-        self::assertTrue(isset($content['CurrentVersion']['Version']));
+        self::assertIsObject($content->CurrentVersion->Version);
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-1507](https://jira.ez.no/browse/IBX-1507)
| **Type**| bug
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As of now, `Location` visitor is not returning crucial info like `CurrentVersion` which breaks some things for example when creating Image Asset on the fly.

The presented solution is just one option, other would be for example changing how the content on the fly fetches data: https://github.com/ezsystems/ezplatform-admin-ui/blob/2.3/src/bundle/ui-dev/src/modules/universal-discovery/content.create.tab.module.js#L57 - right now it's done using `findLocationsById` but it could be changed to `findContentInfo` for example. This is rather a matter of design decision therefore discussion is welcome. 

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
