### PR TITLE
Fixed return type declarations in RestSessionBasedFactory

### DIFF
--- a/src/bundle/DependencyInjection/Security/RestSessionBasedFactory.php
+++ b/src/bundle/DependencyInjection/Security/RestSessionBasedFactory.php
@@ -56,22 +56,22 @@ class RestSessionBasedFactory extends FormLoginFactory
         return $listenerId;
     }
 
-    protected function getListenerId()
+    protected function getListenerId(): string
     {
         return 'ezpublish_rest.security.authentication.listener.session';
     }
 
-    public function getPosition()
+    public function getPosition(): string
     {
         return 'http';
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return 'ezpublish_rest_session';
     }
 
-    protected function createEntryPoint($container, $id, $config, $defaultEntryPoint)
+    protected function createEntryPoint($container, $id, $config, $defaultEntryPoint): ?string
     {
         return $defaultEntryPoint;
     }


### PR DESCRIPTION
This PR fixes below error which occurs after upgrade to Symfony 5.4

`PHP Fatal error: Declaration of EzSystems\EzPlatformRestBundle\DependencyInjection\Security\RestSessionBasedFactory::getPosition() must be compatible with Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory::getPosition(): string`

Base class: https://github.com/symfony/security-bundle/blob/5.4/DependencyInjection/Security/Factory/FormLoginFactory.php

This error occurs for methods which the definition of the return type has been changed.