### PR TITLE
IBX-2264: Handled empty Thumbnail ProxyObject

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/Version.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/Version.php
@@ -136,7 +136,7 @@ class Version extends ValueObjectVisitor
     ): void {
         $generator->startObjectElement('Thumbnail');
 
-        if (!empty($thumbnail)) {
+        if (!empty($thumbnail->resource)) {
             $generator->startValueElement('resource', $thumbnail->resource);
             $generator->endValueElement('resource');
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-2264](https://jira.ez.no/browse/IBX-2264)
| **Type**| bug
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Right now `getThumbnail` can never be `null` (but this is what we have in the interface so this is an inconsistency) due to the implementation of `ProxyObject`, this can cause problems like the one described in the ticket. Potentially later on we could implement some decoy thumbnail or allow Thumbnail with `null` as a resource and change the interface.

Related `ezplatform-kernel` PR: https://github.com/ezsystems/ezplatform-kernel/pull/288

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
