### PR TITLE
IBX-2973: Remove obsolete random sleep on REST login

### DIFF
--- a/src/bundle/Resources/config/default_settings.yml
+++ b/src/bundle/Resources/config/default_settings.yml
@@ -87,7 +87,3 @@ parameters:
         createToken:
             mediaType: 'JWT'
             href: 'router.generate("ibexa.platform.rest.create_token")'
-
-    # Boundary times in microseconds which the authentication check will be delayed by.
-    ibexa.rest.authentication_min_delay_time: 30000
-    ibexa.rest.authentication_max_delay_time: 500000

--- a/src/bundle/Resources/config/security.yml
+++ b/src/bundle/Resources/config/security.yml
@@ -14,8 +14,6 @@ services:
             - "@event_dispatcher"
             - "@ezpublish.config.resolver"
             - "@?logger"
-            - "%ibexa.rest.authentication_min_delay_time%"
-            - "%ibexa.rest.authentication_max_delay_time%"
         abstract: true
 
     ezpublish_rest.security.authentication.logout_handler:

--- a/src/lib/Server/Security/RestAuthenticator.php
+++ b/src/lib/Server/Security/RestAuthenticator.php
@@ -34,10 +34,6 @@ use Symfony\Component\Security\Http\SecurityEvents;
  */
 class RestAuthenticator implements AuthenticatorInterface
 {
-    private const DEFAULT_MIN_SLEEP_VALUE = 30000;
-
-    private const DEFAULT_MAX_SLEEP_VALUE = 500000;
-
     /**
      * @var \Psr\Log\LoggerInterface
      */
@@ -72,25 +68,13 @@ class RestAuthenticator implements AuthenticatorInterface
      */
     private $logoutHandlers = [];
 
-    /**
-     * @var int|null
-     */
-    private $minSleepTime;
-
-    /**
-     * @var int|null
-     */
-    private $maxSleepTime;
-
     public function __construct(
         TokenStorageInterface $tokenStorage,
         AuthenticationManagerInterface $authenticationManager,
         $providerKey,
         EventDispatcherInterface $dispatcher,
         ConfigResolverInterface $configResolver,
-        LoggerInterface $logger = null,
-        $minSleepTime = self::DEFAULT_MIN_SLEEP_VALUE,
-        $maxSleepTime = self::DEFAULT_MAX_SLEEP_VALUE
+        LoggerInterface $logger = null
     ) {
         $this->tokenStorage = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
@@ -98,8 +82,6 @@ class RestAuthenticator implements AuthenticatorInterface
         $this->dispatcher = $dispatcher;
         $this->configResolver = $configResolver;
         $this->logger = $logger;
-        $this->minSleepTime = !is_int($minSleepTime) ? self::DEFAULT_MIN_SLEEP_VALUE : $minSleepTime;
-        $this->maxSleepTime = !is_int($maxSleepTime) ? self::DEFAULT_MAX_SLEEP_VALUE : $maxSleepTime;
     }
 
     /**
@@ -114,8 +96,6 @@ class RestAuthenticator implements AuthenticatorInterface
 
     public function authenticate(Request $request)
     {
-        usleep(random_int($this->minSleepTime, $this->maxSleepTime));
-
         // If a token already exists and username is the same as the one we request authentication for,
         // then return it and mark it as coming from session.
         $previousToken = $this->tokenStorage->getToken();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-2973](https://issues.ibexa.co/browse/IBX-2973)
| **Type**| improvement
| **Target version** | Ibexa DXP `v3.3`
| **BC breaks**      | no
| **Tests pass**     | 1 failure, timeout
| **Doc needed**     | no

Remove the small amount of random sleep on REST login that was made unnecessary with the release of https://issues.ibexa.co/browse/IBX-1755

**TODO**:
- [x] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
