### PR TITLE
IBX-3814: Added imageFields with field identifier to RestContentType for multi-upload functionality

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/RestContentType.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestContentType.php
@@ -156,12 +156,12 @@ class RestContentType extends RestContentTypeBase
 
         $imageFields = $contentType->getFieldDefinitions()->filterByType('ezimage');
         $generator->startHashElement('imageFields');
-        $generator->startList('field');
+        $generator->startList('identifier');
         foreach ($imageFields as $imageField) {
-            $generator->startValueElement('identifier', $imageField->identifier);
-            $generator->endValueElement('identifier');
+            $generator->startValueElement('value', $imageField->identifier);
+            $generator->endValueElement('value');
         }
-        $generator->endList('field');
+        $generator->endList('identifier');
         $generator->endHashElement('imageFields');
 
         $generator->endObjectElement($mediaType);

--- a/src/lib/Server/Output/ValueObjectVisitor/RestContentType.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestContentType.php
@@ -158,8 +158,7 @@ class RestContentType extends RestContentTypeBase
         $generator->startHashElement('imageFields');
         $generator->startList('identifier');
         foreach ($imageFields as $imageField) {
-            $generator->startValueElement('value', $imageField->identifier);
-            $generator->endValueElement('value');
+            $generator->valueElement('value', $imageField->identifier);
         }
         $generator->endList('identifier');
         $generator->endHashElement('imageFields');

--- a/src/lib/Server/Output/ValueObjectVisitor/RestContentType.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestContentType.php
@@ -154,6 +154,16 @@ class RestContentType extends RestContentTypeBase
             );
         }
 
+        $imageFields = $contentType->getFieldDefinitions()->filterByType('ezimage');
+        $generator->startHashElement('imageFields');
+        $generator->startList('field');
+        foreach ($imageFields as $imageField) {
+            $generator->startValueElement('identifier', $imageField->identifier);
+            $generator->endValueElement('identifier');
+        }
+        $generator->endList('field');
+        $generator->endHashElement('imageFields');
+
         $generator->endObjectElement($mediaType);
     }
 }

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestContentTypeTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestContentTypeTest.php
@@ -101,7 +101,7 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
                     'descriptions' => ['eng-GB' => 'Sindelfingen', 'eng-US' => 'Bielefeld'],
 
                     // "Mock"
-                    'fieldDefinitions' => [],
+                    'fieldDefinitions' => new Values\ContentType\FieldDefinitionCollection(),
                 ]
             ),
             []
@@ -376,6 +376,16 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
     public function testDefaultSortOrder(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/ContentType/defaultSortOrder[text()="DESC"]');
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitDefinedType
+     */
+    public function testImageFields(\DOMDocument $dom)
+    {
+        $this->assertXPath($dom, '/ContentType/imageFields');
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-3814](https://issues.ibexa.co/browse/IBX-3814)
| **Type**| bug
| **Target version** | V3.3+
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

To better catch cases when multi-upload functionality needs to add alternativeText to the field, I added imageFields to the returned response containing field identifiers of type ezimage. Thanks to this, in JS we can decide whether to add alternativeText or not.

Related to https://github.com/ezsystems/ezplatform-admin-ui/pull/2078

Response for Content type with ezimage:
```
{
  "_media-type": "application/vnd.ez.api.ContentTypeInfoList+json",
  "_href": "/api/ezp/v2/content/types",
  "ContentType": [
    {
      "_media-type": "application/vnd.ez.api.ContentTypeInfo+json",
      "_href": "/api/ezp/v2/content/types/5",
      "id": 5,
      "status": "DEFINED",
      "identifier": "image",
      "names": {
        "value": [
          {
            "_languageCode": "eng-GB",
            "#text": "Image"
          }
        ]
      },
      "descriptions": {
        "value": [
          {
            "_languageCode": "eng-GB",
            "#text": null
          }
        ]
      },
      "creationDate": "2002-09-08T11:36:32+00:00",
      "modificationDate": "2022-11-17T10:29:54+00:00",
      "Creator": {
        "_media-type": "application/vnd.ez.api.User+json",
        "_href": "/api/ezp/v2/user/users/14"
      },
      "Modifier": {
        "_media-type": "application/vnd.ez.api.User+json",
        "_href": "/api/ezp/v2/user/users/14"
      },
      "Groups": {
        "_media-type": "application/vnd.ez.api.ContentTypeGroupRefList+json",
        "_href": "/api/ezp/v2/content/types/5/groups"
      },
      "Draft": {
        "_media-type": "application/vnd.ez.api.ContentType+json",
        "_href": "/api/ezp/v2/content/types/5/draft"
      },
      "remoteId": "f6df12aa74e36230eb675f364fccd25a",
      "urlAliasSchema": "",
      "nameSchema": "<name>",
      "isContainer": false,
      "mainLanguageCode": "eng-GB",
      "defaultAlwaysAvailable": true,
      "defaultSortField": "PATH",
      "defaultSortOrder": "ASC",
      "imageFields": {
        "identifier": [
          "image"
        ]
      }
    }
  ]
}
```

Response for Content-type file:
```
{
  "_media-type": "application/vnd.ez.api.ContentTypeInfoList+json",
  "_href": "/api/ezp/v2/content/types",
  "ContentType": [
    {
      "_media-type": "application/vnd.ez.api.ContentTypeInfo+json",
      "_href": "/api/ezp/v2/content/types/12",
      "id": 12,
      "status": "DEFINED",
      "identifier": "file",
      "names": {
        "value": [
          {
            "_languageCode": "eng-GB",
            "#text": "File"
          }
        ]
      },
      "descriptions": {
        "value": []
      },
      "creationDate": "2003-05-08T09:17:52+00:00",
      "modificationDate": "2003-05-08T09:21:09+00:00",
      "Creator": {
        "_media-type": "application/vnd.ez.api.User+json",
        "_href": "/api/ezp/v2/user/users/14"
      },
      "Modifier": {
        "_media-type": "application/vnd.ez.api.User+json",
        "_href": "/api/ezp/v2/user/users/14"
      },
      "Groups": {
        "_media-type": "application/vnd.ez.api.ContentTypeGroupRefList+json",
        "_href": "/api/ezp/v2/content/types/12/groups"
      },
      "Draft": {
        "_media-type": "application/vnd.ez.api.ContentType+json",
        "_href": "/api/ezp/v2/content/types/12/draft"
      },
      "remoteId": "637d58bfddf164627bdfd265733280a0",
      "urlAliasSchema": null,
      "nameSchema": "<name>",
      "isContainer": false,
      "mainLanguageCode": "eng-GB",
      "defaultAlwaysAvailable": true,
      "defaultSortField": "PATH",
      "defaultSortOrder": "ASC",
      "imageFields": {
        "identifier": []
      }
    }
  ]
}
```



**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
