### PR TITLE
IBX-3814: Added new endpoint to get field definition by identifier

### DIFF
--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -586,8 +586,7 @@ ezpublish_rest_loadContentTypeFieldDefinition:
         
 ibexa.rest.load_content_type_field_definition_by_identifier:
     path: /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}
-    defaults:
-        _controller: ezpublish_rest.controller.content_type:loadContentTypeFieldDefinitionByIdentifier
+    controller: ezpublish_rest.controller.content_type:loadContentTypeFieldDefinitionByIdentifier
     methods: [GET]
     requirements:
         contentTypeId: \d+

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -583,6 +583,15 @@ ezpublish_rest_loadContentTypeFieldDefinition:
     requirements:
         contentTypeId: \d+
         fieldDefinitionId: \d+
+        
+ezpublish_rest_loadContentTypeFieldDefinitionByIdentifier:
+    path: /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}
+    defaults:
+        _controller: ezpublish_rest.controller.content_type:loadContentTypeFieldDefinitionByIdentifier
+    methods: [GET]
+    requirements:
+        contentTypeId: \d+
+        fieldDefinitionIdentifier: \w+
 
 ezpublish_rest_loadContentTypeDraft:
     path: /content/types/{contentTypeId}/draft

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -584,7 +584,7 @@ ezpublish_rest_loadContentTypeFieldDefinition:
         contentTypeId: \d+
         fieldDefinitionId: \d+
         
-ezpublish_rest_loadContentTypeFieldDefinitionByIdentifier:
+ibexa.rest.load_content_type_field_definition_by_identifier:
     path: /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}
     defaults:
         _controller: ezpublish_rest.controller.content_type:loadContentTypeFieldDefinitionByIdentifier

--- a/src/lib/Server/Controller/ContentType.php
+++ b/src/lib/Server/Controller/ContentType.php
@@ -580,7 +580,9 @@ class ContentType extends RestController
         );
 
         if ($fieldDefinition === null) {
-            throw new Exceptions\NotFoundException(sprintf("Field definition not found: '%s'.", $request->getPathInfo()));
+            throw new Exceptions\NotFoundException(
+                sprintf("Field definition not found: '%s'.", $request->getPathInfo())
+            );
         }
 
         return new Values\RestFieldDefinition(

--- a/src/lib/Server/Controller/ContentType.php
+++ b/src/lib/Server/Controller/ContentType.php
@@ -561,6 +561,35 @@ class ContentType extends RestController
     }
 
     /**
+     * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException
+     */
+    public function loadContentTypeFieldDefinitionByIdentifier(
+        int $contentTypeId,
+        string $fieldDefinitionIdentifier,
+        Request $request
+    ): Values\RestFieldDefinition {
+        $contentType = $this->contentTypeService->loadContentType($contentTypeId, Language::ALL);
+        $fieldDefinition = $contentType->getFieldDefinition($fieldDefinitionIdentifier);
+        $path = $this->router->generate(
+            'ezpublish_rest_loadContentTypeFieldDefinitionByIdentifier',
+            [
+                'contentTypeId' => $contentType->id,
+                'fieldDefinitionIdentifier' => $fieldDefinitionIdentifier,
+            ]
+        );
+
+        if ($fieldDefinition !== null) {
+            return new Values\RestFieldDefinition(
+                $contentType,
+                $fieldDefinition,
+                $path
+            );
+        }
+
+        throw new Exceptions\NotFoundException("Field definition not found: '{$request->getPathInfo()}'.");
+    }
+
+    /**
      * Loads field definitions for a given content type draft.
      *
      * @param $contentTypeId

--- a/src/lib/Server/Controller/ContentType.php
+++ b/src/lib/Server/Controller/ContentType.php
@@ -562,13 +562,14 @@ class ContentType extends RestController
 
     /**
      * @throws \EzSystems\EzPlatformRest\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function loadContentTypeFieldDefinitionByIdentifier(
         int $contentTypeId,
         string $fieldDefinitionIdentifier,
         Request $request
     ): Values\RestFieldDefinition {
-        $contentType = $this->contentTypeService->loadContentType($contentTypeId, Language::ALL);
+        $contentType = $this->contentTypeService->loadContentType($contentTypeId);
         $fieldDefinition = $contentType->getFieldDefinition($fieldDefinitionIdentifier);
         $path = $this->router->generate(
             'ezpublish_rest_loadContentTypeFieldDefinitionByIdentifier',
@@ -578,15 +579,15 @@ class ContentType extends RestController
             ]
         );
 
-        if ($fieldDefinition !== null) {
-            return new Values\RestFieldDefinition(
-                $contentType,
-                $fieldDefinition,
-                $path
-            );
+        if ($fieldDefinition === null) {
+            throw new Exceptions\NotFoundException(sprintf("Field definition not found: '%s'.", $request->getPathInfo()));
         }
 
-        throw new Exceptions\NotFoundException("Field definition not found: '{$request->getPathInfo()}'.");
+        return new Values\RestFieldDefinition(
+            $contentType,
+            $fieldDefinition,
+            $path
+        );
     }
 
     /**

--- a/src/lib/Server/Controller/ContentType.php
+++ b/src/lib/Server/Controller/ContentType.php
@@ -572,7 +572,7 @@ class ContentType extends RestController
         $contentType = $this->contentTypeService->loadContentType($contentTypeId);
         $fieldDefinition = $contentType->getFieldDefinition($fieldDefinitionIdentifier);
         $path = $this->router->generate(
-            'ezpublish_rest_loadContentTypeFieldDefinitionByIdentifier',
+            'ibexa.rest.load_content_type_field_definition_by_identifier',
             [
                 'contentTypeId' => $contentType->id,
                 'fieldDefinitionIdentifier' => $fieldDefinitionIdentifier,

--- a/src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
@@ -54,20 +54,18 @@ class RestFieldDefinition extends RestContentTypeBase
         }
 
         if ($data->path === null) {
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
-                    "ezpublish_rest_loadContentType{$urlTypeSuffix}FieldDefinition",
-                    [
-                        'contentTypeId' => $contentType->id,
-                        'fieldDefinitionId' => $fieldDefinition->id,
-                    ]
-                )
+            $href = $this->router->generate(
+                "ezpublish_rest_loadContentType{$urlTypeSuffix}FieldDefinition",
+                [
+                    'contentTypeId' => $contentType->id,
+                    'fieldDefinitionId' => $fieldDefinition->id,
+                ]
             );
         } else {
-            $generator->startAttribute('href', $data->path);
+            $href = $data->path;
         }
 
+        $generator->startAttribute('href', $href);
         $generator->endAttribute('href');
 
         $generator->startValueElement('id', $fieldDefinition->id);

--- a/src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
@@ -53,16 +53,21 @@ class RestFieldDefinition extends RestContentTypeBase
             $visitor->setHeader('Accept-Patch', $generator->getMediaType('FieldDefinitionUpdate'));
         }
 
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                "ezpublish_rest_loadContentType{$urlTypeSuffix}FieldDefinition",
-                [
-                    'contentTypeId' => $contentType->id,
-                    'fieldDefinitionId' => $fieldDefinition->id,
-                ]
-            )
-        );
+        if ($data->path === null) {
+            $generator->startAttribute(
+                'href',
+                $this->router->generate(
+                    "ezpublish_rest_loadContentType{$urlTypeSuffix}FieldDefinition",
+                    [
+                        'contentTypeId' => $contentType->id,
+                        'fieldDefinitionId' => $fieldDefinition->id,
+                    ]
+                )
+            );
+        } else {
+            $generator->startAttribute('href', $data->path);
+        }
+
         $generator->endAttribute('href');
 
         $generator->startValueElement('id', $fieldDefinition->id);

--- a/src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
@@ -65,8 +65,7 @@ class RestFieldDefinition extends RestContentTypeBase
             $href = $data->path;
         }
 
-        $generator->startAttribute('href', $href);
-        $generator->endAttribute('href');
+        $generator->attribute('href', $href);
 
         $generator->startValueElement('id', $fieldDefinition->id);
         $generator->endValueElement('id');

--- a/src/lib/Server/Values/RestFieldDefinition.php
+++ b/src/lib/Server/Values/RestFieldDefinition.php
@@ -30,14 +30,16 @@ class RestFieldDefinition extends RestValue
     public $fieldDefinition;
 
     /**
-     * Construct.
+     * Path which was used to fetch the list of field definition.
      *
-     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
-     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     * @var string|null
      */
-    public function __construct(ContentType $contentType, FieldDefinition $fieldDefinition)
+    public $path;
+
+    public function __construct(ContentType $contentType, FieldDefinition $fieldDefinition, ?string $path = null)
     {
         $this->contentType = $contentType;
         $this->fieldDefinition = $fieldDefinition;
+        $this->path = $path;
     }
 }

--- a/src/lib/Server/Values/RestFieldDefinition.php
+++ b/src/lib/Server/Values/RestFieldDefinition.php
@@ -30,7 +30,7 @@ class RestFieldDefinition extends RestValue
     public $fieldDefinition;
 
     /**
-     * Path which was used to fetch the list of field definition.
+     * Path which is used to fetch the list of field definitions.
      *
      * @var string|null
      */

--- a/tests/bundle/Functional/ContentTypeTest.php
+++ b/tests/bundle/Functional/ContentTypeTest.php
@@ -447,6 +447,30 @@ XML;
     }
 
     /**
+     * @depends testCreateContentType
+     * Covers GET /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}
+     *
+     * @param string $fieldDefinitionHref
+     *
+     * @throws \Psr\Http\Client\ClientException
+     */
+    public function testLoadContentTypeFieldDefinitionByIdentifier(string $contentTypeHref): void
+    {
+        $url = sprintf('%s/fieldDefinition/title', $contentTypeHref);
+
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('GET', $url, '', 'FieldDefinition+json')
+        );
+
+        self::assertHttpResponseCodeEquals($response, 200);
+
+        $data = json_decode($response->getBody(), true);
+
+        self::assertEquals($url, $data['FieldDefinition']['_href']);
+        self::assertEquals('title', $data['FieldDefinition']['identifier']);
+    }
+
+    /**
      * @depends testAddContentTypeDraftFieldDefinition
      * Covers PATCH /content/types/<contentTypeId>/fieldDefinitions/<fieldDefinitionId>
      *

--- a/tests/bundle/Functional/ContentTypeTest.php
+++ b/tests/bundle/Functional/ContentTypeTest.php
@@ -447,10 +447,9 @@ XML;
     }
 
     /**
-     * @depends testCreateContentType
-     * Covers GET /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}
+     * Covers GET /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}.
      *
-     * @param string $fieldDefinitionHref
+     * @depends testCreateContentType
      *
      * @throws \Psr\Http\Client\ClientException
      */

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
@@ -21,17 +21,24 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $this->fieldTypeSerializerMock = $this->createMock(FieldTypeSerializer::class);
     }
 
-    /**
-     * @return \DOMDocument
-     */
-    public function testVisitRestFieldDefinition()
+    public function testVisitRestFieldDefinition(): \DOMDocument
+    {
+        return $this->generateDomDocument();
+    }
+
+    public function testVisitRestFieldDefinitionWithPath(): \DOMDocument
+    {
+        return $this->generateDomDocument('/content/types/contentTypeId/fieldDefinition/title');
+    }
+
+    protected function generateDomDocument(?string $path = null): \DOMDocument
     {
         $visitor = $this->getVisitor();
         $generator = $this->getGenerator();
 
         $generator->startDocument(null);
 
-        $restFieldDefinition = $this->getBasicRestFieldDefinition();
+        $restFieldDefinition = $this->getBasicRestFieldDefinition($path);
 
         $this->fieldTypeSerializerMock->expects($this->once())
             ->method('serializeFieldDefaultValue')
@@ -43,14 +50,16 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
                 )
             );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentTypeFieldDefinition',
-            [
-                'contentTypeId' => $restFieldDefinition->contentType->id,
-                'fieldDefinitionId' => $restFieldDefinition->fieldDefinition->id,
-            ],
-            "/content/types/{$restFieldDefinition->contentType->id}/fieldDefinitions/{$restFieldDefinition->fieldDefinition->id}"
-        );
+        if ($path === null) {
+            $this->addRouteExpectation(
+                'ezpublish_rest_loadContentTypeFieldDefinition',
+                [
+                    'contentTypeId' => $restFieldDefinition->contentType->id,
+                    'fieldDefinitionId' => $restFieldDefinition->fieldDefinition->id,
+                ],
+                "/content/types/{$restFieldDefinition->contentType->id}/fieldDefinitions/{$restFieldDefinition->fieldDefinition->id}"
+            );
+        }
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -68,7 +77,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         return $dom;
     }
 
-    protected function getBasicRestFieldDefinition()
+    protected function getBasicRestFieldDefinition(?string $path = null): Server\Values\RestFieldDefinition
     {
         return new Server\Values\RestFieldDefinition(
             new Values\ContentType\ContentType(
@@ -95,14 +104,40 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
                     'names' => ['eng-US' => 'Sindelfingen'],
                     'descriptions' => ['eng-GB' => 'Bielefeld'],
                 ]
-            )
+            ),
+            $path
         );
     }
 
-    public function provideXpathAssertions()
+    public function provideXpathAssertions(): array
     {
-        $xpathAssertions = [
-            '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinitions/fieldDefinitionId_23"]',
+        $xpathAssertions = $this->getXpathAssertions();
+        $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinitions/fieldDefinitionId_23"]';
+
+        return array_map(
+            function ($xpath) {
+                return [$xpath];
+            },
+            $xpathAssertions
+        );
+    }
+
+    public function provideXpathAssertionsPath(): array
+    {
+        $xpathAssertions = $this->getXpathAssertions();
+        $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinition/title"]';
+
+        return array_map(
+            function ($xpath) {
+                return [$xpath];
+            },
+            $xpathAssertions
+        );
+    }
+
+    protected function getXpathAssertions(): array
+    {
+        return [
             '/FieldDefinition[@media-type="application/vnd.ez.api.FieldDefinition+xml"]',
             '/FieldDefinition/id[text()="fieldDefinitionId_23"]',
             '/FieldDefinition/identifier[text()="title"]',
@@ -117,33 +152,30 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
             '/FieldDefinition/names/value[@languageCode="eng-US" and text()="Sindelfingen"]',
             '/FieldDefinition/descriptions/value[@languageCode="eng-GB" and text()="Bielefeld"]',
         ];
-
-        return array_map(
-            function ($xpath) {
-                return [$xpath];
-            },
-            $xpathAssertions
-        );
     }
 
     /**
-     * @param string $xpath
-     * @param \DOMDocument $dom
-     *
      * @depends testVisitRestFieldDefinition
      * @dataProvider provideXpathAssertions
      */
-    public function testGeneratedXml($xpath, \DOMDocument $dom)
+    public function testGeneratedXml(string $xpath, \DOMDocument $dom): void
+    {
+        $this->assertXPath($dom, $xpath);
+    }
+
+    /**
+     * @depends testVisitRestFieldDefinitionWithPath
+     * @dataProvider provideXpathAssertionsPath
+     */
+    public function testGeneratedXmlPath(string $xpath, \DOMDocument $dom): void
     {
         $this->assertXPath($dom, $xpath);
     }
 
     /**
      * Get the Content visitor.
-     *
-     * @return \EzSystems\EzPlatformRest\Server\Output\ValueObjectVisitor\RestFieldDefinition
      */
-    protected function internalGetVisitor()
+    protected function internalGetVisitor(): ValueObjectVisitor\RestFieldDefinition
     {
         return new ValueObjectVisitor\RestFieldDefinition($this->fieldTypeSerializerMock);
     }

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
@@ -114,12 +114,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $xpathAssertions = $this->getXpathAssertions();
         $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinitions/fieldDefinitionId_23"]';
 
-        return array_map(
-            function (string $xpath): array {
-                return [$xpath];
-            },
-            $xpathAssertions
-        );
+        return $this->prepareXPathAssertions($xpathAssertions);
     }
 
     public function provideXpathAssertionsPath(): array
@@ -127,6 +122,11 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $xpathAssertions = $this->getXpathAssertions();
         $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinition/title"]';
 
+        return $this->prepareXPathAssertions($xpathAssertions);
+    }
+
+    protected function prepareXPathAssertions(array $xpathAssertions): array
+    {
         return array_map(
             function (string $xpath): array {
                 return [$xpath];

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
@@ -115,7 +115,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinitions/fieldDefinitionId_23"]';
 
         return array_map(
-            function (array $xpath): array {
+            function (string $xpath): array {
                 return [$xpath];
             },
             $xpathAssertions
@@ -128,7 +128,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinition/title"]';
 
         return array_map(
-            function (array $xpath): array {
+            function (string $xpath): array {
                 return [$xpath];
             },
             $xpathAssertions

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
@@ -128,7 +128,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
     protected function prepareXPathAssertions(array $xpathAssertions): array
     {
         return array_map(
-            function (string $xpath): array {
+            static function (string $xpath): array {
                 return [$xpath];
             },
             $xpathAssertions

--- a/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
@@ -115,7 +115,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinitions/fieldDefinitionId_23"]';
 
         return array_map(
-            function ($xpath) {
+            function (array $xpath): array {
                 return [$xpath];
             },
             $xpathAssertions
@@ -128,7 +128,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
         $xpathAssertions[] = '/FieldDefinition[@href="/content/types/contentTypeId/fieldDefinition/title"]';
 
         return array_map(
-            function ($xpath) {
+            function (array $xpath): array {
                 return [$xpath];
             },
             $xpathAssertions


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-3814](https://issues.ibexa.co/browse/IBX-3814)
| **Type**| bug
| **Target version** | V3.3+
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

For the purpose of the multi-upload functionality in BO, an endpoint for getting field def has been added by the identifier (in admin-UI we use the identifier of the field to define which field will be used to upload the file).

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
