### PR TITLE
IBX-5119: Handled empty `mainLocationId` in `Server\Output\ValueObjectVisitor\Location`

### DIFF
--- a/src/bundle/Resources/config/value_object_visitors.yml
+++ b/src/bundle/Resources/config/value_object_visitors.yml
@@ -601,8 +601,6 @@ services:
         arguments:
             $locationService: '@ezpublish.api.service.location'
             $contentService: '@ezpublish.api.service.content'
-        calls:
-            - [setLogger, ['@?logger']]
 
     ezpublish_rest.output.value_object_visitor.LocationList:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/src/bundle/Resources/config/value_object_visitors.yml
+++ b/src/bundle/Resources/config/value_object_visitors.yml
@@ -601,6 +601,8 @@ services:
         arguments:
             $locationService: '@ezpublish.api.service.location'
             $contentService: '@ezpublish.api.service.content'
+        calls:
+            - [setLogger, ['@?logger']]
 
     ezpublish_rest.output.value_object_visitor.LocationList:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/src/lib/Server/Output/ValueObjectVisitor/Location.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/Location.php
@@ -162,7 +162,7 @@ class Location extends ValueObjectVisitor
         $generator->endAttribute('href');
 
         $content = $location->getContent();
-        $contentInfo = $location->contentInfo;
+        $contentInfo = $location->getContentInfo();
         $mainLocation = $this->resolveMainLocation($contentInfo, $location);
 
         $visitor->visitValueObject(new RestContentValue(
@@ -184,7 +184,7 @@ class Location extends ValueObjectVisitor
         Content\ContentInfo $contentInfo,
         Content\Location $location
     ): ?Content\Location {
-        $mainLocationId = $contentInfo->mainLocationId;
+        $mainLocationId = $contentInfo->getMainLocationId();
         if ($mainLocationId === null) {
             return null;
         }

--- a/src/lib/Server/Output/ValueObjectVisitor/Location.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/Location.php
@@ -14,18 +14,12 @@ use EzSystems\EzPlatformRest\Output\ValueObjectVisitor;
 use EzSystems\EzPlatformRest\Output\Generator;
 use EzSystems\EzPlatformRest\Output\Visitor;
 use EzSystems\EzPlatformRest\Server\Values\RestContent as RestContentValue;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * Location value object visitor.
  */
-class Location extends ValueObjectVisitor implements LoggerAwareInterface
+class Location extends ValueObjectVisitor
 {
-    use LoggerAwareTrait;
-
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
@@ -34,12 +28,10 @@ class Location extends ValueObjectVisitor implements LoggerAwareInterface
 
     public function __construct(
         LocationService $locationService,
-        ContentService $contentService,
-        ?LoggerInterface $logger = null
+        ContentService $contentService
     ) {
         $this->locationService = $locationService;
         $this->contentService = $contentService;
-        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -194,10 +186,6 @@ class Location extends ValueObjectVisitor implements LoggerAwareInterface
     ): ?Content\Location {
         $mainLocationId = $contentInfo->mainLocationId;
         if ($mainLocationId === null) {
-            $this->logger->warning(
-                sprintf('Main location for content of ID = %d doesn\'t exist.', $contentInfo->id)
-            );
-
             return null;
         }
 

--- a/src/lib/Server/Output/ValueObjectVisitor/Location.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/Location.php
@@ -14,22 +14,32 @@ use EzSystems\EzPlatformRest\Output\ValueObjectVisitor;
 use EzSystems\EzPlatformRest\Output\Generator;
 use EzSystems\EzPlatformRest\Output\Visitor;
 use EzSystems\EzPlatformRest\Server\Values\RestContent as RestContentValue;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Location value object visitor.
  */
-class Location extends ValueObjectVisitor
+class Location extends ValueObjectVisitor implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /** @var \eZ\Publish\API\Repository\LocationService */
     private $locationService;
 
     /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
-    public function __construct(LocationService $locationService, ContentService $contentService)
-    {
+    public function __construct(
+        LocationService $locationService,
+        ContentService $contentService,
+        ?LoggerInterface $logger = null
+    ) {
         $this->locationService = $locationService;
         $this->contentService = $contentService;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -184,6 +194,10 @@ class Location extends ValueObjectVisitor
     ): ?Content\Location {
         $mainLocationId = $contentInfo->mainLocationId;
         if ($mainLocationId === null) {
+            $this->logger->warning(
+                sprintf('Main location for content of ID = %d doesn\'t exist.', $contentInfo->id)
+            );
+
             return null;
         }
 

--- a/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
@@ -76,7 +76,7 @@ final class LocationTest extends ValueObjectVisitorBaseTest
 
         $result = $generator->endDocument(null);
 
-        $this->assertNotNull($result);
+        self::assertNotNull($result);
 
         return $result;
     }

--- a/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
@@ -8,60 +8,75 @@ namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location as ApiLocation;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use EzSystems\EzPlatformRest\Tests\Output\ValueObjectVisitorBaseTest;
 use EzSystems\EzPlatformRest\Server\Output\ValueObjectVisitor;
+use PHPUnit\Framework\MockObject\MockObject;
 
 final class LocationTest extends ValueObjectVisitorBaseTest
 {
-    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private const MAIN_LOCATION_ID = 78;
+
+    private const UNAUTHORIZED_MAIN_LOCATION_ID = 111;
+
+    private const LOCATION_ID = 55;
+
+    /** @var \eZ\Publish\API\Repository\LocationService|MockObject */
     private $locationServiceMock;
 
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var ContentService|MockObject */
     private $contentServiceMock;
 
     protected function setUp(): void
     {
+        $this->permissionResolverMock = $this->createMock(PermissionResolver::class);
         $this->locationServiceMock = $this->createMock(LocationService::class);
         $this->contentServiceMock = $this->createMock(ContentService::class);
 
         parent::setUp();
     }
 
-    public function testVisitWithDifferentLocationToMainLocation(): string
-    {
+    /**
+     * @dataProvider providerForMainLocationId
+     */
+    public function testVisitLocationWithDifferentContentMainLocations(
+        ?int $mainLocationId,
+        int $locationId
+    ): void {
         $visitor = $this->getVisitor();
         $generator = $this->getGenerator();
 
         $generator->startDocument(null);
 
+        $contentId = 7;
+        $versionInfo = new VersionInfo();
+
         $location = new Location([
-            'id' => 55,
+            'id' => $locationId,
             'path' => ['1', '25', '42'],
             'priority' => 1,
             'sortField' => ApiLocation::SORT_FIELD_DEPTH,
             'sortOrder' => ApiLocation::SORT_ORDER_ASC,
             'parentLocationId' => 42,
             'contentInfo' => new ContentInfo([
-                'id' => $contentId = 7,
-                'mainLocationId' => $mainLocationId = 78,
+                'id' => $contentId,
+                'mainLocationId' => $mainLocationId,
             ]),
             'content' => new Content([
                 'id' => $contentId,
                 'contentType' => new ContentType(),
-                'versionInfo' => $versionInfo = new VersionInfo(),
+                'versionInfo' => $versionInfo,
             ]),
         ]);
 
-        $this->locationServiceMock->expects(self::once())
-            ->method('loadLocation')
-            ->with($mainLocationId)
-            ->willReturn(new Location(['id' => $mainLocationId]));
+        $this->mockLoadLocation($location);
 
         $this->contentServiceMock->expects(self::once())
             ->method('loadRelations')
@@ -78,14 +93,6 @@ final class LocationTest extends ValueObjectVisitorBaseTest
 
         self::assertNotNull($result);
 
-        return $result;
-    }
-
-    /**
-     * @depends testVisitWithDifferentLocationToMainLocation
-     */
-    public function testResultContainsLocationListElement(string $result): void
-    {
         $this->assertXMLTag(
             [
                 'tag' => 'Location',
@@ -93,21 +100,51 @@ final class LocationTest extends ValueObjectVisitorBaseTest
             $result,
             'Invalid <Location> element.',
         );
-    }
 
-    /**
-     * @depends testVisitWithDifferentLocationToMainLocation
-     */
-    public function testResultContainsLocationAttributes(string $result): void
-    {
         $this->assertXMLTag(
             [
                 'tag' => 'Location',
-                'content' => 55 . 1 . 'false' . 'false',
+                'content' => $location->id . 1 . 'false' . 'false',
             ],
             $result,
             'Invalid <Location> attributes.',
         );
+    }
+
+    private function mockLoadLocation(Location $location): void
+    {
+        $mainLocationId = $location->getContentInfo()->getMainLocationId();
+
+        switch ($mainLocationId) {
+            case $location->id:
+            case null:
+                $this->locationServiceMock->expects(self::never())
+                    ->method('loadLocation');
+                break;
+            case self::UNAUTHORIZED_MAIN_LOCATION_ID:
+                $this->locationServiceMock->expects(self::once())
+                    ->method('loadLocation')
+                    ->with($mainLocationId)
+                    ->willThrowException(new UnauthorizedException('', ''));
+                break;
+            default:
+                $this->locationServiceMock->expects(self::once())
+                    ->method('loadLocation')
+                    ->with($mainLocationId)
+                    ->willReturn(new Location(['id' => $mainLocationId]));
+                break;
+        }
+    }
+
+    public function providerForMainLocationId(): iterable
+    {
+        yield 'same' => [self::MAIN_LOCATION_ID, self::MAIN_LOCATION_ID];
+
+        yield 'empty-main-location' => [null, self::LOCATION_ID];
+
+        yield 'different' => [999, self::LOCATION_ID];
+
+        yield 'unauthorized' => [self::UNAUTHORIZED_MAIN_LOCATION_ID, self::LOCATION_ID];
     }
 
     protected function internalGetVisitor(): ValueObjectVisitor\Location

--- a/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location as ApiLocation;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use EzSystems\EzPlatformRest\Tests\Output\ValueObjectVisitorBaseTest;
+use EzSystems\EzPlatformRest\Server\Output\ValueObjectVisitor;
+
+final class LocationTest extends ValueObjectVisitorBaseTest
+{
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private $locationServiceMock;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->locationServiceMock = $this->createMock(LocationService::class);
+        $this->contentServiceMock = $this->createMock(ContentService::class);
+
+        parent::setUp();
+    }
+
+    public function testVisitWithDifferentLocationToMainLocation(): string
+    {
+        $visitor = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument(null);
+
+        $location = new Location([
+            'id' => 55,
+            'path' => ['1', '25', '42'],
+            'priority' => 1,
+            'sortField' => ApiLocation::SORT_FIELD_DEPTH,
+            'sortOrder' => ApiLocation::SORT_ORDER_ASC,
+            'parentLocationId' => 42,
+            'contentInfo' => new ContentInfo([
+                'id' => $contentId = 7,
+                'mainLocationId' => $mainLocationId = 78,
+            ]),
+            'content' => new Content([
+                'id' => $contentId,
+                'contentType' => new ContentType(),
+                'versionInfo' => $versionInfo = new VersionInfo(),
+            ])
+        ]);
+
+        $this->locationServiceMock->expects(self::once())
+            ->method('loadLocation')
+            ->with($mainLocationId)
+            ->willReturn(new Location(['id' => $mainLocationId]));
+
+        $this->contentServiceMock->expects(self::once())
+            ->method('loadRelations')
+            ->with($versionInfo)
+            ->willReturn([]);
+
+        $visitor->visit(
+            $this->getVisitorMock(),
+            $generator,
+            $location
+        );
+
+        $result = $generator->endDocument(null);
+
+        $this->assertNotNull($result);
+
+        return $result;
+    }
+
+    /**
+     * @depends testVisitWithDifferentLocationToMainLocation
+     */
+    public function testResultContainsLocationListElement(string $result): void
+    {
+        $this->assertXMLTag(
+            [
+                'tag' => 'Location',
+            ],
+            $result,
+            'Invalid <Location> element.',
+        );
+    }
+
+    /**
+     * @depends testVisitWithDifferentLocationToMainLocation
+     */
+    public function testResultContainsLocationAttributes(string $result): void
+    {
+        $this->assertXMLTag(
+            [
+                'tag' => 'Location',
+                'content' => 55 . 1 . 'false' . 'false',
+            ],
+            $result,
+            'Invalid <Location> attributes.',
+        );
+    }
+
+    protected function internalGetVisitor(): ValueObjectVisitor\Location
+    {
+        return new ValueObjectVisitor\Location($this->locationServiceMock, $this->contentServiceMock);
+    }
+}

--- a/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
@@ -44,9 +44,9 @@ final class LocationTest extends ValueObjectVisitorBaseTest
     }
 
     /**
-     * @dataProvider providerForMainLocationId
+     * @dataProvider getDataForTestVisitLocationAttributesResolvesMainLocation
      */
-    public function testVisitLocationWithDifferentContentMainLocations(
+    public function testVisitLocationAttributesResolvesMainLocation(
         ?int $mainLocationId,
         int $locationId
     ): void {
@@ -96,18 +96,10 @@ final class LocationTest extends ValueObjectVisitorBaseTest
         $this->assertXMLTag(
             [
                 'tag' => 'Location',
-            ],
-            $result,
-            'Invalid <Location> element.',
-        );
-
-        $this->assertXMLTag(
-            [
-                'tag' => 'Location',
                 'content' => $location->id . 1 . 'false' . 'false',
             ],
             $result,
-            'Invalid <Location> attributes.',
+            'Invalid <Location> element.',
         );
     }
 
@@ -136,7 +128,7 @@ final class LocationTest extends ValueObjectVisitorBaseTest
         }
     }
 
-    public function providerForMainLocationId(): iterable
+    public function getDataForTestVisitLocationAttributesResolvesMainLocation(): iterable
     {
         yield 'same' => [self::MAIN_LOCATION_ID, self::MAIN_LOCATION_ID];
 

--- a/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/LocationTest.php
@@ -4,7 +4,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
 use eZ\Publish\API\Repository\ContentService;
@@ -56,7 +55,7 @@ final class LocationTest extends ValueObjectVisitorBaseTest
                 'id' => $contentId,
                 'contentType' => new ContentType(),
                 'versionInfo' => $versionInfo = new VersionInfo(),
-            ])
+            ]),
         ]);
 
         $this->locationServiceMock->expects(self::once())


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5119](https://jira.ez.no/browse/IBX-5119)
| **Type**| bug
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Proper handling was added.

Requires: https://github.com/ezsystems/ezplatform-kernel/pull/364

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
