### PR TITLE
Fixed tests: Check cookies in redirection response, not post redirect

### DIFF
--- a/tests/bundle/Functional/SessionTest.php
+++ b/tests/bundle/Functional/SessionTest.php
@@ -113,6 +113,7 @@ class SessionTest extends TestCase
         self::assertGreaterThan(0, $csrfDomElements->length);
         $csrfTokenValue = $csrfDomElements->item(0)->nodeValue;
 
+        $browser->followRedirects(false);
         $browser->submitForm(
             'Login',
             [


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Type**| improvement
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes check that cookie was set in the browser when login was performed.

Backport of https://github.com/ibexa/rest/pull/53

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
