### PR TITLE
IBX-6239: Added Content Type for Image Variation

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/ImageVariation.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/ImageVariation.php
@@ -18,6 +18,7 @@ class ImageVariation extends ValueObjectVisitor
      */
     public function visit(Visitor $visitor, Generator $generator, $data)
     {
+        $visitor->setHeader('Content-Type', $generator->getMediaType('ContentImageVariation'));
         $generator->startObjectElement('ContentImageVariation');
         $this->visitImageVariationAttributes($visitor, $generator, $data);
         $generator->endObjectElement('ContentImageVariation');
@@ -59,7 +60,5 @@ class ImageVariation extends ValueObjectVisitor
             $generator->startValueElement('fileSize', $data->fileSize);
             $generator->endValueElement('fileSize');
         }
-
-        $visitor->setHeader('Content-Type', $generator->getMediaType('ContentImageVariation'));
     }
 }

--- a/src/lib/Server/Output/ValueObjectVisitor/ImageVariation.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/ImageVariation.php
@@ -59,5 +59,7 @@ class ImageVariation extends ValueObjectVisitor
             $generator->startValueElement('fileSize', $data->fileSize);
             $generator->endValueElement('fileSize');
         }
+
+        $visitor->setHeader('Content-Type', $generator->getMediaType('ContentImageVariation'));
     }
 }

--- a/tests/bundle/Functional/ImageVariationTest.php
+++ b/tests/bundle/Functional/ImageVariationTest.php
@@ -16,26 +16,26 @@ final class ImageVariationTest extends RESTFunctionalTestCase
     public function testCreateContent(): string
     {
         $string = $this->addTestSuffix(__FUNCTION__);
-        $fileName = basename('1px.png');
+        $fileName = '1px.png';
         $fileSize = 4718;
         $fileData = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
-
+        $restPrefixPath = '/api/ezp/v2';
         $body = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentCreate>
-  <ContentType href="/api/ezp/v2/content/types/5" />
+  <ContentType href="{$restPrefixPath}/content/types/5" />
   <mainLanguageCode>eng-GB</mainLanguageCode>
   <LocationCreate>
-    <ParentLocation href="/api/ezp/v2/content/locations/1/2" />
+    <ParentLocation href="{$restPrefixPath}/content/locations/1/2" />
     <priority>0</priority>
     <hidden>false</hidden>
     <sortField>PATH</sortField>
     <sortOrder>ASC</sortOrder>
   </LocationCreate>
-  <Section href="/api/ezp/v2/content/sections/3" />
+  <Section href="{$restPrefixPath}/content/sections/3" />
   <alwaysAvailable>true</alwaysAvailable>
   <remoteId>{$string}</remoteId>
-  <User href="/api/ezp/v2/user/users/14" />
+  <User href="{$restPrefixPath}/user/users/14" />
   <modificationDate>2012-09-30T12:30:00</modificationDate>
   <fields>
     <field>
@@ -57,7 +57,7 @@ final class ImageVariationTest extends RESTFunctionalTestCase
 XML;
         $request = $this->createHttpRequest(
             'POST',
-            '/api/ezp/v2/content/objects',
+            $restPrefixPath . '/content/objects',
             'ContentCreate+xml',
             'ContentInfo+json',
             $body
@@ -65,14 +65,18 @@ XML;
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertEquals('201', $response->getStatusCode());
-        self::assertHttpResponseHasHeader($response, 'Location');
-        self::assertHttpResponseHasHeader($response, 'content-type', 'application/vnd.ez.api.ContentInfo+json');
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_CREATED);
+        $this->assertHttpResponseHasHeader($response, 'Location');
+        $this->assertHttpResponseHasHeader($response, 'content-type', 'application/vnd.ez.api.ContentInfo+json');
 
         $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
-        return $href;
+        $contentInfo = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        return sprintf(
+            '%s/%d', $contentInfo['Content']['Versions']['_href'], $contentInfo['Content']['currentVersionNo']
+        );
     }
 
     /**
@@ -81,53 +85,33 @@ XML;
     public function testPublishContent(string $restContentHref): string
     {
         $response = $this->sendHttpRequest(
-            $this->createHttpRequest('PUBLISH', sprintf('%s/versions/1', $restContentHref))
+            $this->createHttpRequest('PUBLISH', $restContentHref)
         );
-        self::assertHttpResponseCodeEquals($response, 204);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_NO_CONTENT);
 
         return $restContentHref;
     }
 
     /**
-     * @depends testCreateContent
-     */
-    public function testLoadContent(string $restContentHref): void
-    {
-        $response = $this->sendHttpRequest(
-            $this->createHttpRequest(
-                'GET',
-                $restContentHref,
-                '',
-                'Version+json'
-            )
-        );
-
-        self::assertHttpResponseCodeEquals($response, 200);
-        self::assertArrayHasKey('content-type', $response->getHeaders());
-        self::assertHttpResponseHasHeader($response, 'content-type', 'application/vnd.ez.api.ContentInfo+json');
-    }
-
-    /**
      * @depends testPublishContent
      */
-    public function testGetImageVariation(string $hrefToImage): void
+    public function testGetImageVariation(string $restVersionHref): void
     {
-        $restContentHref = $hrefToImage;
         $imageResponse = $this->sendHttpRequest(
             $this->createHttpRequest(
                 'GET',
-                $restContentHref . '/versions/1',
+                $restVersionHref,
                 '',
                 'Version+json'
             )
         );
 
-        $jsonResponse = json_decode((string)$imageResponse->getBody());
-        $imageField = $jsonResponse->Version->Fields->field[2];
+        $jsonResponse = json_decode((string)$imageResponse->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        $imageField = $jsonResponse['Version']['Fields']['field'][2];
 
-        self::assertObjectHasAttribute('variations', $imageField->fieldValue);
+        self::assertArrayHasKey('variations', $imageField['fieldValue']);
 
-        $variationUrl = $imageField->fieldValue->variations->medium->href;
+        $variationUrl = $imageField['fieldValue']['variations']['medium']['href'];
 
         $variationResponse = $this->sendHttpRequest(
             $this->createHttpRequest(

--- a/tests/bundle/Functional/ImageVariationTest.php
+++ b/tests/bundle/Functional/ImageVariationTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformRestBundle\Tests\Functional;
+
+use EzSystems\EzPlatformRestBundle\Tests\Functional\TestCase as RESTFunctionalTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ImageVariationTest extends RESTFunctionalTestCase
+{
+    public function testCreateContent(): string
+    {
+        $string = $this->addTestSuffix(__FUNCTION__);
+        $fileName = basename('1px.png');
+        $fileSize = 4718;
+        $fileData = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+        $body = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentCreate>
+  <ContentType href="/api/ezp/v2/content/types/5" />
+  <mainLanguageCode>eng-GB</mainLanguageCode>
+  <LocationCreate>
+    <ParentLocation href="/api/ezp/v2/content/locations/1/2" />
+    <priority>0</priority>
+    <hidden>false</hidden>
+    <sortField>PATH</sortField>
+    <sortOrder>ASC</sortOrder>
+  </LocationCreate>
+  <Section href="/api/ezp/v2/content/sections/3" />
+  <alwaysAvailable>true</alwaysAvailable>
+  <remoteId>{$string}</remoteId>
+  <User href="/api/ezp/v2/user/users/14" />
+  <modificationDate>2012-09-30T12:30:00</modificationDate>
+  <fields>
+    <field>
+      <fieldDefinitionIdentifier>name</fieldDefinitionIdentifier>
+      <languageCode>eng-GB</languageCode>
+      <fieldValue>{$string}</fieldValue>
+    </field>
+    <field>
+      <fieldDefinitionIdentifier>image</fieldDefinitionIdentifier>
+      <languageCode>eng-GB</languageCode>
+      <fieldValue>
+            <value key="fileName">{$fileName}</value>
+            <value key="fileSize">{$fileSize}</value>
+            <value key="data">{$fileData}</value>
+      </fieldValue>
+    </field>
+  </fields>
+</ContentCreate>
+XML;
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/content/objects',
+            'ContentCreate+xml',
+            'ContentInfo+json',
+            $body
+        );
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertEquals('201', $response->getStatusCode());
+        self::assertHttpResponseHasHeader($response, 'Location');
+        self::assertHttpResponseHasHeader($response, 'content-type', 'application/vnd.ez.api.ContentInfo+json');
+
+        $href = $response->getHeader('Location')[0];
+        $this->addCreatedElement($href);
+
+        return $href;
+    }
+
+    /**
+     * @depends testCreateContent
+     */
+    public function testPublishContent(string $restContentHref): string
+    {
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('PUBLISH', sprintf('%s/versions/1', $restContentHref))
+        );
+        self::assertHttpResponseCodeEquals($response, 204);
+
+        return $restContentHref;
+    }
+
+    /**
+     * @depends testCreateContent
+     */
+    public function testLoadContent(string $restContentHref): void
+    {
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest(
+                'GET',
+                $restContentHref,
+                '',
+                'Version+json'
+            )
+        );
+
+        self::assertHttpResponseCodeEquals($response, 200);
+        self::assertArrayHasKey('content-type', $response->getHeaders());
+        self::assertHttpResponseHasHeader($response, 'content-type', 'application/vnd.ez.api.ContentInfo+json');
+    }
+
+    /**
+     * @depends testPublishContent
+     */
+    public function testGetImageVariation(string $hrefToImage): void
+    {
+        $restContentHref = $hrefToImage;
+        $imageResponse = $this->sendHttpRequest(
+            $this->createHttpRequest(
+                'GET',
+                $restContentHref . '/versions/1',
+                '',
+                'Version+json'
+            )
+        );
+
+        $jsonResponse = json_decode((string)$imageResponse->getBody());
+        $imageField = $jsonResponse->Version->Fields->field[2];
+
+        self::assertObjectHasAttribute('variations', $imageField->fieldValue);
+
+        $variationUrl = $imageField->fieldValue->variations->medium->href;
+
+        $variationResponse = $this->sendHttpRequest(
+            $this->createHttpRequest(
+                'GET',
+                $variationUrl,
+                '',
+                'Version+json'
+            )
+        );
+        self::assertHttpResponseCodeEquals($variationResponse, Response::HTTP_OK);
+        self::assertHttpResponseHasHeader(
+            $variationResponse,
+            'content-type',
+            'application/vnd.ez.api.ContentImageVariation+json'
+        );
+    }
+}

--- a/tests/bundle/Functional/TestCase.php
+++ b/tests/bundle/Functional/TestCase.php
@@ -87,7 +87,7 @@ class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->httpHost = getenv('EZP_TEST_REST_HOST') ?: '127.0.0.1:8000';
+        $this->httpHost = getenv('EZP_TEST_REST_HOST') ?: 'localhost';
         $this->httpScheme = getenv('EZP_TEST_REST_SCHEME') ?: 'http';
         $this->httpAuth = getenv('EZP_TEST_REST_AUTH') ?: 'admin:publish';
         [$this->loginUsername, $this->loginPassword] = explode(':', $this->httpAuth);

--- a/tests/bundle/Functional/TestCase.php
+++ b/tests/bundle/Functional/TestCase.php
@@ -87,7 +87,7 @@ class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->httpHost = getenv('EZP_TEST_REST_HOST') ?: 'localhost';
+        $this->httpHost = getenv('EZP_TEST_REST_HOST') ?: '127.0.0.1:8000';
         $this->httpScheme = getenv('EZP_TEST_REST_SCHEME') ?: 'http';
         $this->httpAuth = getenv('EZP_TEST_REST_AUTH') ?: 'admin:publish';
         [$this->loginUsername, $this->loginPassword] = explode(':', $this->httpAuth);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6239](https://jira.ez.no/browse/IBX-6239)
| **Type**           | bug
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

## Summary

This PR updates the Content-Type header in the image variation endpoint(```/api/ezp/v2/content/binary/images/270-999-1/variations/medium```) and adds an integration test for it.

### Changes
- Content-Type Header: Updated from ```text/html``` to ```application/vnd.ez.api.ContentImageVariation+xml```.
- New Test: Added an integration test for the ImageVariation endpoint.

## TODO:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
