### PR TITLE
IBX-5827: Replaced deprecated string interpolation (PHP 8.2+)

### DIFF
--- a/src/lib/Server/Input/Parser/Criterion.php
+++ b/src/lib/Server/Input/Parser/Criterion.php
@@ -64,7 +64,7 @@ abstract class Criterion extends BaseParser
         try {
             return $parsingDispatcher->parse([$facetBuilderName => $facetBuilderData], $mediaType);
         } catch (Exceptions\Parser $e) {
-            throw new Exceptions\Parser("Invalid FacetBuilder id <${facetBuilderName}>", 0, $e);
+            throw new Exceptions\Parser("Invalid FacetBuilder id <{$facetBuilderName}>", 0, $e);
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-5827